### PR TITLE
Fix: empty response on chunked transfer encoding

### DIFF
--- a/custom_components/bookstack_sync/api.py
+++ b/custom_components/bookstack_sync/api.py
@@ -141,11 +141,11 @@ class BookStackApiClient:
                     headers=headers,
                 )
                 _raise_for_status(response)
-                if (
-                    response.status == HTTPStatus.NO_CONTENT
-                    or not response.content_length
-                ):
+                if response.status == HTTPStatus.NO_CONTENT:
                     return {}
+                # Don't gate on Content-Length: BookStack uses chunked
+                # transfer encoding, so content_length is None even when
+                # there is a JSON body to parse.
                 return await response.json()
         except BookStackApiError:
             raise


### PR DESCRIPTION
BookStack uses Transfer-Encoding: chunked for JSON responses. aiohttp's esponse.content_length is None for chunked encoding, which our short-circuit treated as empty body and returned {} without parsing the JSON.

Result: every API call returned an empty dict, list_books() always returned [], and the config flow displayed 
o books found even though the token, URL and permissions were correct.

Fix: only short-circuit on HTTP 204 No Content; let aiohttp parse the body for all other 2xx responses.

Fixes the In dieser BookStack-Instanz wurde kein Book gefunden error users were hitting in v0.1.1.