### PR TITLE
v0.2.0 - Chapters, overview links, status sensor, progress feedback

### DIFF
--- a/custom_components/bookstack_sync/__init__.py
+++ b/custom_components/bookstack_sync/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from homeassistant.const import Platform
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.loader import async_get_loaded_integration
 
@@ -31,7 +32,7 @@ if TYPE_CHECKING:
 
     from .data import BookStackSyncConfigEntry
 
-PLATFORMS: list = []  # services-only integration; no entities in V0
+PLATFORMS: list[Platform] = [Platform.SENSOR]
 
 
 async def async_setup_entry(
@@ -58,21 +59,31 @@ async def async_setup_entry(
         store=store,
     )
 
-    if coordinator.update_interval is not None:
-        await coordinator.async_config_entry_first_refresh()
-
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     await async_register_services(hass)
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+
+    # Trigger the initial sync in the background so the integration finishes
+    # setup quickly. The status sensor, per-page log lines and the persistent
+    # notification let the user follow progress without blocking HA's UI.
+    if coordinator.update_interval is not None:
+        entry.async_create_background_task(
+            hass,
+            coordinator.async_request_refresh(),
+            "bookstack_sync_initial_refresh",
+        )
+
     return True
 
 
 async def async_unload_entry(
     hass: HomeAssistant,
-    entry: BookStackSyncConfigEntry,  # noqa: ARG001 - entry unused; HA contract
+    entry: BookStackSyncConfigEntry,
 ) -> bool:
-    """Unload a config entry and tear down services if it was the last one."""
+    """Unload platforms + services for this config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     await async_unregister_services(hass)
-    return True
+    return unload_ok
 
 
 async def _async_update_listener(

--- a/custom_components/bookstack_sync/api.py
+++ b/custom_components/bookstack_sync/api.py
@@ -69,35 +69,65 @@ class BookStackApiClient:
             params={"filter[book_id]": str(book_id)},
         )
 
+    async def list_chapters(self, book_id: int) -> list[dict[str, Any]]:
+        """Return all chapters in the given book."""
+        return await self._list_paginated(
+            "/api/chapters",
+            params={"filter[book_id]": str(book_id)},
+        )
+
+    async def create_chapter(
+        self,
+        book_id: int,
+        name: str,
+        description: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a new chapter inside the given book."""
+        body: dict[str, Any] = {"book_id": book_id, "name": name}
+        if description:
+            body["description"] = description
+        return await self._request("post", "/api/chapters", json=body)
+
     async def get_page(self, page_id: int) -> dict[str, Any]:
         """Fetch a single page including markdown body."""
         return await self._request("get", f"/api/pages/{page_id}")
 
     async def create_page(
         self,
-        book_id: int,
         name: str,
         markdown: str,
+        *,
+        book_id: int | None = None,
+        chapter_id: int | None = None,
     ) -> dict[str, Any]:
-        """Create a markdown page inside the given book."""
-        return await self._request(
-            "post",
-            "/api/pages",
-            json={"book_id": book_id, "name": name, "markdown": markdown},
-        )
+        """
+        Create a markdown page either at book-level or inside a chapter.
+
+        Exactly one of ``book_id`` and ``chapter_id`` must be provided.
+        """
+        if (book_id is None) == (chapter_id is None):
+            msg = "create_page needs exactly one of book_id or chapter_id"
+            raise BookStackApiError(msg)
+        body: dict[str, Any] = {"name": name, "markdown": markdown}
+        if chapter_id is not None:
+            body["chapter_id"] = chapter_id
+        else:
+            body["book_id"] = book_id
+        return await self._request("post", "/api/pages", json=body)
 
     async def update_page(
         self,
         page_id: int,
         name: str,
         markdown: str,
+        *,
+        chapter_id: int | None = None,
     ) -> dict[str, Any]:
-        """Update an existing markdown page."""
-        return await self._request(
-            "put",
-            f"/api/pages/{page_id}",
-            json={"name": name, "markdown": markdown},
-        )
+        """Update an existing markdown page; optionally move it to a chapter."""
+        body: dict[str, Any] = {"name": name, "markdown": markdown}
+        if chapter_id is not None:
+            body["chapter_id"] = chapter_id
+        return await self._request("put", f"/api/pages/{page_id}", json=body)
 
     async def _list_paginated(
         self,

--- a/custom_components/bookstack_sync/const.py
+++ b/custom_components/bookstack_sync/const.py
@@ -47,6 +47,18 @@ PAGE_KIND_SCENES = "scenes"
 PAGE_KIND_INTEGRATIONS = "integrations"
 PAGE_KIND_ADDONS = "addons"
 
+# Chapters group the many area/device pages so the book stays readable.
+CHAPTER_KEY_AREAS = "areas"
+CHAPTER_KEY_DEVICES = "devices"
+CHAPTER_TITLE_AREAS = "Räume"
+CHAPTER_TITLE_DEVICES = "Geräte"
+CHAPTER_DESC_AREAS = (
+    "Pro Raum eine Page mit den dort angesiedelten Geräten und Entities."
+)
+CHAPTER_DESC_DEVICES = (
+    "Pro Gerät eine Page mit Stammdaten und allen zugehörigen Entities."
+)
+
 SERVICE_RUN_NOW = "run_now"
 SERVICE_PREVIEW = "preview"
 

--- a/custom_components/bookstack_sync/renderer.py
+++ b/custom_components/bookstack_sync/renderer.py
@@ -73,8 +73,19 @@ def render_tombstone_auto_block(now: datetime) -> str:
     )
 
 
-def render_overview_auto_block(snapshot: HASnapshot, now: datetime) -> str:
-    """Render the AUTO block of the overview page."""
+def render_overview_auto_block(
+    snapshot: HASnapshot,
+    now: datetime,
+    page_links: dict[str, int] | None = None,
+) -> str:
+    """
+    Render the AUTO block of the overview page.
+
+    ``page_links`` maps page keys (e.g. ``area:living_room``) to BookStack
+    page IDs. When provided, area names and category links use BookStack's
+    ``[label](page:ID)`` internal-link syntax instead of plain text.
+    """
+    links = page_links or {}
     total_devices = sum(len(area.devices) for area in snapshot.areas) + len(
         snapshot.unassigned_devices,
     )
@@ -96,14 +107,32 @@ def render_overview_auto_block(snapshot: HASnapshot, now: datetime) -> str:
         f"- Szenen: **{len(snapshot.scenes)}**",
         f"- Add-ons: **{len(snapshot.addons)}**",
         "",
-        "## Räume",
+        "## Bereiche",
         "",
     ]
+    bundle_links = [
+        ("integrations:_", "Integrationen"),
+        ("automations:_", "Automatisierungen"),
+        ("scripts:_", "Skripte"),
+        ("scenes:_", "Szenen"),
+        ("addons:_", "Add-ons"),
+    ]
+    for key, label in bundle_links:
+        page_id = links.get(key)
+        if page_id is not None:
+            lines.append(f"- [{label}](page:{page_id})")
+        else:
+            lines.append(f"- {label}")
+
+    lines.extend(["", "## Räume", ""])
     if snapshot.areas:
-        lines.extend(
-            f"- **{_md_escape(area.name)}** – {len(area.devices)} Geräte"
-            for area in snapshot.areas
-        )
+        for area in snapshot.areas:
+            label = _md_escape(area.name)
+            page_id = links.get(f"area:{area.area_id}")
+            link = (
+                f"[{label}](page:{page_id})" if page_id is not None else f"**{label}**"
+            )
+            lines.append(f"- {link} – {len(area.devices)} Geräte")
     else:
         lines.append("_Keine Areas konfiguriert._")
 
@@ -115,9 +144,11 @@ def render_overview_auto_block(snapshot: HASnapshot, now: datetime) -> str:
                 "",
             ],
         )
-        lines.extend(
-            f"- {_md_escape(device.name)}" for device in snapshot.unassigned_devices
-        )
+        for device in snapshot.unassigned_devices:
+            label = _md_escape(device.name)
+            page_id = links.get(f"device:{device.device_id}")
+            link = f"[{label}](page:{page_id})" if page_id is not None else label
+            lines.append(f"- {link}")
 
     return "\n".join(lines)
 

--- a/custom_components/bookstack_sync/sensor.py
+++ b/custom_components/bookstack_sync/sensor.py
@@ -1,0 +1,99 @@
+"""Status sensor for the BookStack Sync coordinator."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import ATTRIBUTION, DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from .coordinator import BookStackSyncCoordinator
+    from .data import BookStackSyncConfigEntry
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,  # noqa: ARG001 - HA contract
+    entry: BookStackSyncConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Register the single status sensor for this entry."""
+    async_add_entities([BookStackSyncStatusSensor(entry.runtime_data.coordinator)])
+
+
+class BookStackSyncStatusSensor(CoordinatorEntity, SensorEntity):
+    """
+    Surfaces the result of the last sync run as a single sensor entity.
+
+    The state is one of ``ok`` / ``error`` / ``never_run``; the counts and the
+    last-run timestamp live as attributes so they can be put on a dashboard
+    or used in automations.
+    """
+
+    _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
+    _attr_translation_key = "sync_status"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:book-sync"
+
+    def __init__(self, coordinator: BookStackSyncCoordinator) -> None:
+        """Bind to the coordinator and seed identifiers."""
+        super().__init__(coordinator)
+        entry_id = coordinator.config_entry.entry_id
+        self._attr_unique_id = f"{entry_id}_sync_status"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry_id)},
+            name=coordinator.config_entry.title,
+            manufacturer="BookStack Sync",
+            entry_type=None,
+        )
+
+    @property
+    def native_value(self) -> str:
+        """Top-level status: ``ok``, ``error`` or ``never_run``."""
+        report = self.coordinator.last_report
+        if report is None:
+            return "never_run"
+        if report.errors:
+            return "error"
+        return "ok"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Counts + timestamp for the last completed sync."""
+        report = self.coordinator.last_report
+        last_run = self.coordinator.last_run
+        if report is None:
+            return {
+                "last_run": None,
+                "created": 0,
+                "updated": 0,
+                "unchanged": 0,
+                "tombstoned": 0,
+                "skipped_conflict": 0,
+                "errors": [],
+                "total_pages": 0,
+            }
+        return {
+            "last_run": last_run.isoformat() if last_run else None,
+            "created": len(report.created),
+            "updated": len(report.updated),
+            "unchanged": len(report.unchanged),
+            "tombstoned": len(report.tombstoned),
+            "skipped_conflict": len(report.skipped_conflict),
+            "errors": report.errors,
+            "total_pages": (
+                len(report.created)
+                + len(report.updated)
+                + len(report.unchanged)
+                + len(report.tombstoned)
+                + len(report.skipped_conflict)
+            ),
+        }

--- a/custom_components/bookstack_sync/store.py
+++ b/custom_components/bookstack_sync/store.py
@@ -28,6 +28,7 @@ class StoredState:
     """Whole persisted state per config entry."""
 
     pages: dict[str, PageMapping] = field(default_factory=dict)
+    chapters: dict[str, int] = field(default_factory=dict)
 
 
 class BookStackSyncStore:
@@ -55,15 +56,22 @@ class BookStackSyncStore:
             return
         raw = await self._store.async_load() or {}
         pages_raw = raw.get("pages", {}) or {}
+        chapters_raw = raw.get("chapters", {}) or {}
         self._state = StoredState(
             pages={key: PageMapping(**value) for key, value in pages_raw.items()},
+            chapters={key: int(value) for key, value in chapters_raw.items()},
         )
         self._loaded = True
 
     async def async_save(self) -> None:
         """Persist the current mapping state."""
         await self._store.async_save(
-            {"pages": {key: asdict(value) for key, value in self._state.pages.items()}},
+            {
+                "pages": {
+                    key: asdict(value) for key, value in self._state.pages.items()
+                },
+                "chapters": dict(self._state.chapters),
+            },
         )
 
     def get(self, key: str) -> PageMapping | None:
@@ -77,3 +85,15 @@ class BookStackSyncStore:
     def all(self) -> dict[str, PageMapping]:
         """Return a shallow copy of all known mappings."""
         return dict(self._state.pages)
+
+    def get_chapter(self, key: str) -> int | None:
+        """Return the BookStack chapter id for ``key`` (e.g. ``areas``)."""
+        return self._state.chapters.get(key)
+
+    def set_chapter(self, key: str, chapter_id: int) -> None:
+        """Insert or replace the chapter id for ``key`` (call async_save to persist)."""
+        self._state.chapters[key] = chapter_id
+
+    def all_chapters(self) -> dict[str, int]:
+        """Return a shallow copy of the persisted chapter map."""
+        return dict(self._state.chapters)

--- a/custom_components/bookstack_sync/strings.json
+++ b/custom_components/bookstack_sync/strings.json
@@ -69,5 +69,18 @@
       "name": "Sync-Vorschau",
       "description": "Loggt, welche Pages erstellt/aktualisiert würden, schreibt aber nichts in BookStack."
     }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Sync-Status",
+        "state": {
+          "ok": "OK",
+          "error": "Fehler",
+          "never_run": "Noch nicht gelaufen",
+          "syncing": "Sync läuft"
+        }
+      }
+    }
   }
 }

--- a/custom_components/bookstack_sync/sync.py
+++ b/custom_components/bookstack_sync/sync.py
@@ -1,4 +1,14 @@
-"""Sync orchestrator: snapshot HA -> render -> merge -> push to BookStack."""
+"""
+Sync orchestrator: snapshot HA -> render -> merge -> push to BookStack.
+
+Flow per run:
+1. ``ensure_chapters`` makes sure ``Räume`` + ``Geräte`` chapters exist.
+2. Pass 1 syncs all area / device / bundle pages and collects their page IDs.
+3. Pass 2 renders the Übersicht with markdown links to the IDs from pass 1
+   and writes it.
+4. Pages whose HA object has vanished get a one-time tombstone block.
+5. Mapping store is persisted and a persistent notification is posted.
+"""
 
 from __future__ import annotations
 
@@ -7,8 +17,18 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from homeassistant.components.persistent_notification import (
+    async_create as async_create_notification,
+)
+
 from .api import BookStackApiAuthError, BookStackApiError
 from .const import (
+    CHAPTER_DESC_AREAS,
+    CHAPTER_DESC_DEVICES,
+    CHAPTER_KEY_AREAS,
+    CHAPTER_KEY_DEVICES,
+    CHAPTER_TITLE_AREAS,
+    CHAPTER_TITLE_DEVICES,
     LOGGER,
     PAGE_KIND_ADDONS,
     PAGE_KIND_AREA,
@@ -88,9 +108,12 @@ class SyncReport:
 
 @dataclass
 class _PlannedPage:
+    """One page we want to ensure exists / is up to date."""
+
     key: str
     title: str
     auto_body: str
+    chapter_key: str | None = None  # None = page lives at book level
 
 
 def _device_page(device: DeviceSnapshot, now: datetime) -> _PlannedPage:
@@ -98,16 +121,13 @@ def _device_page(device: DeviceSnapshot, now: datetime) -> _PlannedPage:
         key=f"{PAGE_KIND_DEVICE}:{device.device_id}",
         title=f"Gerät: {device.name}",
         auto_body=render_device_auto_block(device, now),
+        chapter_key=CHAPTER_KEY_DEVICES,
     )
 
 
 def _plan_pages(snapshot: HASnapshot, now: datetime) -> list[_PlannedPage]:
+    """Plan all pages EXCEPT the overview (rendered in a second pass)."""
     planned: list[_PlannedPage] = [
-        _PlannedPage(
-            key=f"{PAGE_KIND_OVERVIEW}:_",
-            title="Home Assistant – Übersicht",
-            auto_body=render_overview_auto_block(snapshot, now),
-        ),
         _PlannedPage(
             key=f"{PAGE_KIND_INTEGRATIONS}:_",
             title="Home Assistant – Integrationen",
@@ -143,11 +163,43 @@ def _plan_pages(snapshot: HASnapshot, now: datetime) -> list[_PlannedPage]:
                 key=f"{PAGE_KIND_AREA}:{area.area_id}",
                 title=f"Raum: {area.name}",
                 auto_body=render_area_auto_block(area, now),
+                chapter_key=CHAPTER_KEY_AREAS,
             ),
         )
         planned.extend(_device_page(d, now) for d in area.devices)
     planned.extend(_device_page(d, now) for d in snapshot.unassigned_devices)
     return planned
+
+
+async def _ensure_chapters(
+    client: BookStackApiClient,
+    store: BookStackSyncStore,
+    book_id: int,
+) -> dict[str, int]:
+    """Make sure the area + device chapters exist; return their IDs."""
+    desired = (
+        (CHAPTER_KEY_AREAS, CHAPTER_TITLE_AREAS, CHAPTER_DESC_AREAS),
+        (CHAPTER_KEY_DEVICES, CHAPTER_TITLE_DEVICES, CHAPTER_DESC_DEVICES),
+    )
+    existing_chapters = await client.list_chapters(book_id)
+    existing_ids = {int(ch["id"]) for ch in existing_chapters}
+    by_name = {ch["name"]: int(ch["id"]) for ch in existing_chapters}
+
+    chapters: dict[str, int] = {}
+    for key, title, description in desired:
+        stored_id = store.get_chapter(key)
+        if stored_id and stored_id in existing_ids:
+            chapters[key] = stored_id
+            continue
+        if title in by_name:
+            chapters[key] = by_name[title]
+            continue
+        created = await client.create_chapter(book_id, title, description=description)
+        chapters[key] = int(created["id"])
+
+    for key, chapter_id in chapters.items():
+        store.set_chapter(key, chapter_id)
+    return chapters
 
 
 async def run_sync(  # noqa: PLR0913 - cohesive entry point
@@ -169,10 +221,26 @@ async def run_sync(  # noqa: PLR0913 - cohesive entry point
     planned = _plan_pages(snapshot, now)
 
     await store.async_load()
+    chapters = {} if dry_run else await _ensure_chapters(client, store, book_id)
 
-    for page in planned:
+    # Pass 1: sync all non-overview pages, collect their IDs for the overview.
+    page_ids: dict[str, int] = {}
+    total_steps = len(planned) + 1  # +1 for the overview pass
+    for index, page in enumerate(planned, start=1):
         try:
-            await _sync_one(client, store, book_id, page, report, dry_run=dry_run)
+            page_id = await _sync_one(
+                client,
+                store,
+                book_id,
+                page,
+                chapters,
+                report,
+                index=index,
+                total=total_steps,
+                dry_run=dry_run,
+            )
+            if page_id is not None:
+                page_ids[page.key] = page_id
         except BookStackApiAuthError:
             raise
         except BookStackApiError as err:
@@ -184,7 +252,32 @@ async def run_sync(  # noqa: PLR0913 - cohesive entry point
         if not dry_run:
             await asyncio.sleep(WRITE_PAUSE_SECONDS)
 
-    await _tombstone_orphans(client, store, planned, report, now, dry_run=dry_run)
+    # Pass 2: render overview with page links + sync it.
+    overview = _PlannedPage(
+        key=f"{PAGE_KIND_OVERVIEW}:_",
+        title="Home Assistant – Übersicht",
+        auto_body=render_overview_auto_block(snapshot, now, page_links=page_ids),
+    )
+    try:
+        await _sync_one(
+            client,
+            store,
+            book_id,
+            overview,
+            chapters,
+            report,
+            index=total_steps,
+            total=total_steps,
+            dry_run=dry_run,
+        )
+    except BookStackApiAuthError:
+        raise
+    except BookStackApiError as err:
+        LOGGER.exception("BookStack sync failed for overview")
+        report.errors.append(f"{overview.key}: {err}")
+
+    all_planned = [overview, *planned]
+    await _tombstone_orphans(client, store, all_planned, report, now, dry_run=dry_run)
 
     if not dry_run:
         await store.async_save()
@@ -200,7 +293,26 @@ async def run_sync(  # noqa: PLR0913 - cohesive entry point
         len(report.errors),
         " (dry-run)" if dry_run else "",
     )
+    if not dry_run:
+        _post_sync_notification(hass, report)
     return report
+
+
+def _post_sync_notification(hass: HomeAssistant, report: SyncReport) -> None:
+    bullet = (
+        f"- {len(report.created)} angelegt\n"
+        f"- {len(report.updated)} aktualisiert\n"
+        f"- {len(report.unchanged)} unverändert\n"
+        f"- {len(report.tombstoned)} verwaist (Tombstone)\n"
+        f"- {len(report.skipped_conflict)} mit Konflikt übersprungen\n"
+        f"- {len(report.errors)} Fehler"
+    )
+    async_create_notification(
+        hass,
+        f"BookStack-Sync abgeschlossen:\n\n{bullet}",
+        title="BookStack Sync",
+        notification_id="bookstack_sync_last_run",
+    )
 
 
 async def _sync_one(  # noqa: PLR0913 - cohesive sync step, splitting hurts clarity
@@ -208,31 +320,58 @@ async def _sync_one(  # noqa: PLR0913 - cohesive sync step, splitting hurts clar
     store: BookStackSyncStore,
     book_id: int,
     page: _PlannedPage,
+    chapters: dict[str, int],
     report: SyncReport,
     *,
+    index: int,
+    total: int,
     dry_run: bool,
-) -> None:
+) -> int | None:
+    """Sync one page; return the BookStack page id (or None on dry-run create)."""
+    chapter_id = chapters.get(page.chapter_key) if page.chapter_key else None
     new_hash = hash_auto_block(page.auto_body)
     mapping = store.get(page.key)
+
+    LOGGER.info(
+        "BookStack sync %d/%d: %s",
+        index,
+        total,
+        page.title,
+    )
 
     if mapping is None:
         if dry_run:
             report.created.append(page.title)
-            return
+            return None
         body = build_page_body(page.auto_body, "")
-        created = await client.create_page(book_id, page.title, body)
+        if chapter_id is not None:
+            created = await client.create_page(
+                page.title,
+                body,
+                chapter_id=chapter_id,
+            )
+        else:
+            created = await client.create_page(
+                page.title,
+                body,
+                book_id=book_id,
+            )
+        page_id = int(created["id"])
         store.set(
             page.key,
             PageMapping(
-                page_id=int(created["id"]),
+                page_id=page_id,
                 auto_block_hash=new_hash,
                 last_seen=datetime.now(tz=UTC).isoformat(),
             ),
         )
         report.created.append(page.title)
-        return
+        return page_id
 
     existing = await client.get_page(mapping.page_id)
+    existing_chapter_id = existing.get("chapter_id") or 0
+    needs_move = chapter_id is not None and int(existing_chapter_id) != chapter_id
+
     existing_markdown = existing.get("markdown") or existing.get("raw_html") or ""
     existing_auto = extract_auto_block(existing_markdown)
     existing_auto_hash = hash_auto_block(existing_auto) if existing_auto else None
@@ -251,19 +390,24 @@ async def _sync_one(  # noqa: PLR0913 - cohesive sync step, splitting hurts clar
             mapping.page_id,
         )
         report.skipped_conflict.append(page.title)
-        return
+        return mapping.page_id
 
-    if existing_auto_hash == new_hash:
+    if existing_auto_hash == new_hash and not needs_move:
         report.unchanged.append(page.title)
         mapping.last_seen = datetime.now(tz=UTC).isoformat()
         store.set(page.key, mapping)
-        return
+        return mapping.page_id
 
     if dry_run:
         report.updated.append(page.title)
-        return
+        return mapping.page_id
 
-    await client.update_page(mapping.page_id, page.title, merged.body)
+    await client.update_page(
+        mapping.page_id,
+        page.title,
+        merged.body,
+        chapter_id=chapter_id if needs_move else None,
+    )
     store.set(
         page.key,
         PageMapping(
@@ -274,6 +418,7 @@ async def _sync_one(  # noqa: PLR0913 - cohesive sync step, splitting hurts clar
         ),
     )
     report.updated.append(page.title)
+    return mapping.page_id
 
 
 async def _tombstone_orphans(  # noqa: PLR0913 - cohesive sync step

--- a/custom_components/bookstack_sync/translations/de.json
+++ b/custom_components/bookstack_sync/translations/de.json
@@ -69,5 +69,18 @@
       "name": "Sync-Vorschau",
       "description": "Loggt, welche Pages erstellt/aktualisiert würden, schreibt aber nichts in BookStack."
     }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Sync-Status",
+        "state": {
+          "ok": "OK",
+          "error": "Fehler",
+          "never_run": "Noch nicht gelaufen",
+          "syncing": "Sync läuft"
+        }
+      }
+    }
   }
 }

--- a/custom_components/bookstack_sync/translations/en.json
+++ b/custom_components/bookstack_sync/translations/en.json
@@ -69,5 +69,18 @@
       "name": "Sync preview",
       "description": "Logs which pages would be created/updated without writing anything to BookStack."
     }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Sync status",
+        "state": {
+          "ok": "OK",
+          "error": "Error",
+          "never_run": "Never run",
+          "syncing": "Sync running"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Restructures BookStack output into chapters and adds UX improvements:

- **Chapters**: areas under Räume, devices under Geräte - migrated on next sync from flat layout.
- **Overview as TOC**: clickable BookStack page-links to every area + bundle.
- **Status sensor** with last-run counts + state.
- **Per-page log lines** during sync.
- **Persistent notification** on completion.
- **Non-blocking setup**: initial refresh runs as background task.