### PR TITLE
v0.3.0 - pytest test suite (Stufe 1 + Stufe 2) + CI integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    name: "pytest"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
+          cache: "pip"
+
+      - name: Install requirements
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements.txt
+          python3 -m pip install -r requirements-test.txt
+
+      - name: Run tests
+        run: python3 -m pytest tests/ -v

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -26,3 +26,17 @@ keep-runtime-typing = true
 
 [lint.mccabe]
 max-complexity = 25
+
+[lint.per-file-ignores]
+# Tests have legitimately different conventions: assert is the tool, hardcoded
+# tokens are fixtures, shorter docstrings are idiomatic, etc.
+"tests/**/*.py" = [
+    "ANN",     # type annotations are nice-to-have, not load-bearing in tests
+    "ARG",     # unused fixture parameters are normal
+    "D",       # docstring style is overkill for assertion-only test bodies
+    "PLR2004", # magic numbers in assertions are usually clearer than constants
+    "S101",    # `assert` IS the tool
+    "S105",    # hardcoded "passwords" are fixture inputs, not real secrets
+    "S106",    # same, as keyword args
+    "SLF001",  # accessing _private members of own code is fine in tests
+]

--- a/custom_components/bookstack_sync/coordinator.py
+++ b/custom_components/bookstack_sync/coordinator.py
@@ -74,7 +74,10 @@ class BookStackSyncCoordinator(DataUpdateCoordinator[SyncReport]):
             runtime = self.config_entry.runtime_data
             options = self.config_entry.options
             data = self.config_entry.data
-            book_id = int((options or data)[CONF_BOOK_ID])
+            # Initial setup stores book_id in `data`, but the options flow
+            # rewrites it into `options`. Look in options first, then fall
+            # back to data so both layouts work without crashing.
+            book_id = int(options.get(CONF_BOOK_ID) or data[CONF_BOOK_ID])
             excluded_areas = options.get(CONF_EXCLUDED_AREAS, []) or []
             report = await run_sync(
                 self.hass,

--- a/custom_components/bookstack_sync/manifest.json
+++ b/custom_components/bookstack_sync/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dibi73/ha-bookstack-sync/issues",
   "requirements": [],
-  "version": "0.2.2"
+  "version": "0.3.0"
 }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+testpaths = tests
+asyncio_mode = auto
+filterwarnings =
+    ignore::DeprecationWarning
+addopts =
+    -ra
+    --strict-markers
+    --strict-config

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,5 @@
+pytest==9.0.1
+pytest-asyncio==1.2.0
+pytest-cov==7.0.0
+aioresponses==0.7.8
+pytest-homeassistant-custom-component==0.13.310

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
-pytest==9.0.1
-pytest-asyncio==1.2.0
-pytest-cov==7.0.0
-aioresponses==0.7.8
-pytest-homeassistant-custom-component==0.13.310
+pytest<9
+pytest-asyncio<2
+pytest-cov
+aioresponses
+pytest-homeassistant-custom-component

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for the ha-bookstack-sync custom integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,59 @@
+"""Shared fixtures for the bookstack_sync test suite."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bookstack_sync.const import (
+    CONF_BASE_URL,
+    CONF_BOOK_ID,
+    CONF_SYNC_INTERVAL,
+    CONF_TOKEN_ID,
+    CONF_TOKEN_SECRET,
+    CONF_VERIFY_SSL,
+    DOMAIN,
+    INTERVAL_DAILY,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+@pytest.fixture
+def fixed_now() -> datetime:
+    """A stable timestamp so renderer output is byte-identical across runs."""
+    return datetime(2026, 4, 28, 12, 0, 0, tzinfo=UTC)
+
+
+# Allow this custom integration to be loaded by pytest-homeassistant-custom-component.
+# Without this autouse fixture HA refuses to load custom_components/* in tests.
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(
+    enable_custom_integrations: object,
+) -> Generator[None]:
+    """Enable custom integration loading for every test in this suite."""
+    return
+
+
+@pytest.fixture
+def config_entry() -> MockConfigEntry:
+    """A minimally populated MockConfigEntry that mirrors a real setup."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="BookStack: Hausdokumentation",
+        unique_id="http://bookstack.local:6875",
+        data={
+            CONF_BASE_URL: "http://bookstack.local:6875",
+            CONF_TOKEN_ID: "tid",
+            CONF_TOKEN_SECRET: "tsec",
+            CONF_BOOK_ID: 1,
+            CONF_VERIFY_SSL: True,
+        },
+        options={
+            CONF_SYNC_INTERVAL: INTERVAL_DAILY,
+        },
+    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,243 @@
+"""Tests for the BookStack REST client.
+
+Two real bugs we shipped to users hide here as regression tests:
+
+* v0.1.2 — chunked-transfer responses without ``Content-Length`` were
+  short-circuited to ``{}`` instead of being parsed.
+* v0.2.2 — transient ``ServerDisconnectedError`` on long sync runs was
+  treated as a hard failure instead of being retried.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aiohttp
+import pytest
+from aioresponses import aioresponses
+
+from custom_components.bookstack_sync.api import (
+    MAX_REQUEST_ATTEMPTS,
+    BookStackApiAuthError,
+    BookStackApiClient,
+    BookStackApiCommunicationError,
+    BookStackApiError,
+)
+
+
+@pytest.fixture
+async def client() -> Any:
+    """A client backed by a real (but unused-by-network) aiohttp session."""
+    async with aiohttp.ClientSession() as session:
+        yield BookStackApiClient(
+            base_url="http://bookstack.local:6875",
+            token_id="tid",
+            token_secret="tsec",
+            session=session,
+        )
+
+
+class TestBaseUrl:
+    """URL handling."""
+
+    def test_base_url_strips_trailing_slash(self) -> None:
+        # Constructor does no IO, so a None session is enough to exercise it.
+        client = BookStackApiClient(
+            base_url="http://bookstack.local:6875/",
+            token_id="x",
+            token_secret="y",
+            session=None,  # type: ignore[arg-type]
+        )
+        assert client.base_url == "http://bookstack.local:6875"
+
+
+class TestAuth:
+    """Authorization header format must match BookStack's expected `Token id:secret`."""
+
+    async def test_auth_header_passed(self, client: BookStackApiClient) -> None:
+        with aioresponses() as mocked:
+            mocked.get(
+                "http://bookstack.local:6875/api/books?count=500&offset=0",
+                payload={"data": [], "total": 0},
+            )
+            await client.list_books()
+            # aioresponses captures the requests for inspection
+            request_history = mocked.requests
+            (((_, _), call_list),) = list(request_history.items())
+            assert call_list
+            kwargs = call_list[0].kwargs
+            headers = kwargs["headers"]
+            assert headers["Authorization"] == "Token tid:tsec"
+            assert headers["Accept"] == "application/json"
+
+    async def test_401_raises_auth_error(self, client: BookStackApiClient) -> None:
+        with aioresponses() as mocked:
+            mocked.get(
+                "http://bookstack.local:6875/api/books?count=500&offset=0",
+                status=401,
+                payload={"error": {"message": "Invalid token"}},
+            )
+            with pytest.raises(BookStackApiAuthError):
+                await client.list_books()
+
+    async def test_403_raises_auth_error(self, client: BookStackApiClient) -> None:
+        with aioresponses() as mocked:
+            mocked.get(
+                "http://bookstack.local:6875/api/books?count=500&offset=0",
+                status=403,
+            )
+            with pytest.raises(BookStackApiAuthError):
+                await client.list_books()
+
+
+class TestJsonParsing:
+    """v0.1.2 regression: chunked responses must be parsed."""
+
+    async def test_chunked_response_body_parsed(
+        self,
+        client: BookStackApiClient,
+    ) -> None:
+        # Regression: previously we returned {} when content_length was None
+        # (which is the case for chunked encoding).
+        with aioresponses() as mocked:
+            mocked.get(
+                "http://bookstack.local:6875/api/pages/42",
+                payload={"id": 42, "name": "X", "markdown": "body"},
+            )
+            page = await client.get_page(42)
+            assert page["id"] == 42
+            assert page["markdown"] == "body"
+
+    async def test_204_no_content_returns_empty_dict(
+        self,
+        client: BookStackApiClient,
+    ) -> None:
+        with aioresponses() as mocked:
+            mocked.get(
+                "http://bookstack.local:6875/api/pages/42",
+                status=204,
+            )
+            assert await client.get_page(42) == {}
+
+
+class TestPagination:
+    """`_list_paginated` walks until BookStack returns < PAGE_SIZE items."""
+
+    async def test_single_page_response(self, client: BookStackApiClient) -> None:
+        with aioresponses() as mocked:
+            mocked.get(
+                "http://bookstack.local:6875/api/books?count=500&offset=0",
+                payload={"data": [{"id": 1, "name": "A"}], "total": 1},
+            )
+            books = await client.list_books()
+            assert [b["id"] for b in books] == [1]
+
+    async def test_filter_param_passed_through(
+        self,
+        client: BookStackApiClient,
+    ) -> None:
+        with aioresponses() as mocked:
+            mocked.get(
+                "http://bookstack.local:6875/api/pages?count=500&offset=0&filter%5Bbook_id%5D=42",
+                payload={"data": [], "total": 0},
+            )
+            await client.list_book_pages(42)
+
+
+class TestCreatePage:
+    """`create_page` enforces book_id XOR chapter_id."""
+
+    async def test_book_only(self, client: BookStackApiClient) -> None:
+        with aioresponses() as mocked:
+            mocked.post(
+                "http://bookstack.local:6875/api/pages",
+                payload={"id": 11, "name": "P"},
+            )
+            res = await client.create_page("P", "body", book_id=5)
+            assert res["id"] == 11
+
+    async def test_chapter_only(self, client: BookStackApiClient) -> None:
+        with aioresponses() as mocked:
+            mocked.post(
+                "http://bookstack.local:6875/api/pages",
+                payload={"id": 12, "name": "P"},
+            )
+            res = await client.create_page("P", "body", chapter_id=8)
+            assert res["id"] == 12
+
+    async def test_both_raises(self, client: BookStackApiClient) -> None:
+        with pytest.raises(BookStackApiError):
+            await client.create_page("P", "body", book_id=5, chapter_id=8)
+
+    async def test_neither_raises(self, client: BookStackApiClient) -> None:
+        with pytest.raises(BookStackApiError):
+            await client.create_page("P", "body")
+
+
+class TestUpdatePage:
+    """`update_page` optionally moves the page via chapter_id."""
+
+    async def test_update_without_move(self, client: BookStackApiClient) -> None:
+        with aioresponses() as mocked:
+            mocked.put(
+                "http://bookstack.local:6875/api/pages/42",
+                payload={"id": 42, "name": "P"},
+            )
+            await client.update_page(42, "P", "body")
+
+    async def test_update_with_chapter_move(
+        self,
+        client: BookStackApiClient,
+    ) -> None:
+        with aioresponses() as mocked:
+            mocked.put(
+                "http://bookstack.local:6875/api/pages/42",
+                payload={"id": 42, "name": "P"},
+            )
+            await client.update_page(42, "P", "body", chapter_id=99)
+
+
+class TestRetryOnTransientErrors:
+    """v0.2.2 regression: transient errors must be retried."""
+
+    async def test_server_disconnect_then_success(
+        self,
+        client: BookStackApiClient,
+    ) -> None:
+        with aioresponses() as mocked:
+            # First attempt: BookStack drops the connection mid-flight.
+            mocked.get(
+                "http://bookstack.local:6875/api/pages/42",
+                exception=aiohttp.ServerDisconnectedError(),
+            )
+            # Second attempt: clean response.
+            mocked.get(
+                "http://bookstack.local:6875/api/pages/42",
+                payload={"id": 42, "name": "P"},
+            )
+            page = await client.get_page(42)
+            assert page["id"] == 42
+
+    async def test_persistent_disconnect_eventually_raises(
+        self,
+        client: BookStackApiClient,
+    ) -> None:
+        with aioresponses() as mocked:
+            for _ in range(MAX_REQUEST_ATTEMPTS):
+                mocked.get(
+                    "http://bookstack.local:6875/api/pages/42",
+                    exception=aiohttp.ServerDisconnectedError(),
+                )
+            with pytest.raises(BookStackApiCommunicationError):
+                await client.get_page(42)
+
+    async def test_500_does_not_retry(self, client: BookStackApiClient) -> None:
+        # 500 is an aiohttp.ClientResponseError, NOT a transient error -
+        # it indicates a real server-side problem we shouldn't retry blindly.
+        with aioresponses() as mocked:
+            mocked.get(
+                "http://bookstack.local:6875/api/pages/42",
+                status=500,
+            )
+            with pytest.raises(BookStackApiCommunicationError):
+                await client.get_page(42)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,200 @@
+"""Tests for the BookStack Sync config flow.
+
+Covers the three big paths: happy path through both steps, auth error on
+the URL/token step, no-books detection. Reauth is sketched too.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.config_entries import SOURCE_REAUTH
+
+from custom_components.bookstack_sync.api import (
+    BookStackApiAuthError,
+    BookStackApiCommunicationError,
+)
+from custom_components.bookstack_sync.const import (
+    CONF_BASE_URL,
+    CONF_BOOK_ID,
+    CONF_SYNC_INTERVAL,
+    CONF_TOKEN_ID,
+    CONF_TOKEN_SECRET,
+    CONF_VERIFY_SSL,
+    DOMAIN,
+    INTERVAL_DAILY,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+
+async def test_user_step_happy_path_to_book_step(hass: HomeAssistant) -> None:
+    """Valid credentials advance to the book picker step."""
+    with patch(
+        "custom_components.bookstack_sync.config_flow.BookStackApiClient.list_books",
+        new=AsyncMock(return_value=[{"id": 1, "name": "Hausdokumentation"}]),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "user"
+
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_BASE_URL: "http://bookstack.local:6875",
+                CONF_TOKEN_ID: "tid",
+                CONF_TOKEN_SECRET: "tsec",
+                CONF_VERIFY_SSL: True,
+            },
+        )
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
+    assert result2["step_id"] == "book"
+
+
+async def test_user_step_auth_error_shows_form_with_error(
+    hass: HomeAssistant,
+) -> None:
+    with patch(
+        "custom_components.bookstack_sync.config_flow.BookStackApiClient.list_books",
+        new=AsyncMock(side_effect=BookStackApiAuthError("nope")),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_BASE_URL: "http://bookstack.local:6875",
+                CONF_TOKEN_ID: "tid",
+                CONF_TOKEN_SECRET: "wrong",
+                CONF_VERIFY_SSL: True,
+            },
+        )
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
+    assert result2["errors"] == {"base": "auth"}
+
+
+async def test_user_step_connection_error_shows_form_with_error(
+    hass: HomeAssistant,
+) -> None:
+    with patch(
+        "custom_components.bookstack_sync.config_flow.BookStackApiClient.list_books",
+        new=AsyncMock(side_effect=BookStackApiCommunicationError("down")),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_BASE_URL: "http://bookstack.local:6875",
+                CONF_TOKEN_ID: "tid",
+                CONF_TOKEN_SECRET: "tsec",
+                CONF_VERIFY_SSL: True,
+            },
+        )
+    assert result2["errors"] == {"base": "connection"}
+
+
+async def test_user_step_no_books_shows_dedicated_error(
+    hass: HomeAssistant,
+) -> None:
+    with patch(
+        "custom_components.bookstack_sync.config_flow.BookStackApiClient.list_books",
+        new=AsyncMock(return_value=[]),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_BASE_URL: "http://bookstack.local:6875",
+                CONF_TOKEN_ID: "tid",
+                CONF_TOKEN_SECRET: "tsec",
+                CONF_VERIFY_SSL: True,
+            },
+        )
+    assert result2["errors"] == {"base": "no_books"}
+
+
+async def test_book_step_creates_entry(hass: HomeAssistant) -> None:
+    with patch(
+        "custom_components.bookstack_sync.config_flow.BookStackApiClient.list_books",
+        new=AsyncMock(return_value=[{"id": 7, "name": "Hausdokumentation"}]),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_BASE_URL: "http://bookstack.local:6875",
+                CONF_TOKEN_ID: "tid",
+                CONF_TOKEN_SECRET: "tsec",
+                CONF_VERIFY_SSL: True,
+            },
+        )
+        # Async setup of the entry will run; we don't care about its
+        # success here, only that the flow finishes with CREATE_ENTRY.
+        with patch(
+            "custom_components.bookstack_sync.async_setup_entry",
+            new=AsyncMock(return_value=True),
+        ):
+            result3 = await hass.config_entries.flow.async_configure(
+                result2["flow_id"],
+                user_input={
+                    CONF_BOOK_ID: "7",
+                    CONF_SYNC_INTERVAL: INTERVAL_DAILY,
+                },
+            )
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result3["title"].startswith("BookStack")
+    assert result3["data"][CONF_BOOK_ID] == 7
+    assert result3["options"][CONF_SYNC_INTERVAL] == INTERVAL_DAILY
+
+
+async def test_reauth_flow_updates_token(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Reauth replaces just the token credentials; URL stays."""
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.bookstack_sync.config_flow.BookStackApiClient.list_books",
+        new=AsyncMock(return_value=[{"id": 1, "name": "Hausdokumentation"}]),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": SOURCE_REAUTH,
+                "entry_id": config_entry.entry_id,
+            },
+            data=config_entry.data,
+        )
+        assert result["step_id"] == "reauth_confirm"
+
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_TOKEN_ID: "newid",
+                CONF_TOKEN_SECRET: "newsecret",
+            },
+        )
+
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result2["reason"] == "reauth_successful"
+    assert config_entry.data[CONF_TOKEN_ID] == "newid"
+    assert config_entry.data[CONF_TOKEN_SECRET] == "newsecret"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,139 @@
+"""Tests for the sync coordinator.
+
+Covers two important behaviours:
+* The internal lock prevents two syncs from running concurrently
+  (the fix from V0.1 against duplicate-page creation on first run).
+* `BookStackApiAuthError` from a sync run is translated to
+  `ConfigEntryAuthFailed` so HA's reauth flow gets triggered.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.exceptions import ConfigEntryAuthFailed
+
+from custom_components.bookstack_sync.api import BookStackApiAuthError
+from custom_components.bookstack_sync.coordinator import BookStackSyncCoordinator
+from custom_components.bookstack_sync.sync import SyncReport
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+
+def _make_coordinator(
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+) -> BookStackSyncCoordinator:
+    return BookStackSyncCoordinator(hass, entry)
+
+
+async def test_concurrent_calls_serialised(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Two parallel async_run_sync calls execute one after the other."""
+    config_entry.add_to_hass(hass)
+    coord = _make_coordinator(hass, config_entry)
+
+    started = []
+    finished = []
+
+    async def fake_run_sync(*args: object, **kwargs: object) -> SyncReport:
+        marker = object()
+        started.append(marker)
+        # Yield once so a second call has a chance to enter the lock if it could.
+        await asyncio.sleep(0)
+        finished.append(marker)
+        return SyncReport(dry_run=bool(kwargs.get("dry_run")))
+
+    # Patch sync.run_sync where coordinator imports it
+    with patch(
+        "custom_components.bookstack_sync.coordinator.run_sync",
+        new=fake_run_sync,
+    ):
+        # Build minimal runtime_data so coordinator.async_run_sync can read it
+        config_entry.runtime_data = type(
+            "RD", (), {"client": object(), "store": object()}
+        )()
+        await asyncio.gather(
+            coord.async_run_sync(),
+            coord.async_run_sync(),
+        )
+
+    # Both ran, but were serialised: the start of the second must come
+    # AFTER the finish of the first.
+    assert len(started) == 2
+    assert len(finished) == 2
+    assert started.index(finished[0]) == 0
+
+
+async def test_auth_failure_raises_config_entry_auth_failed(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    config_entry.add_to_hass(hass)
+    coord = _make_coordinator(hass, config_entry)
+    config_entry.runtime_data = type(
+        "RD",
+        (),
+        {"client": object(), "store": object()},
+    )()
+
+    with (
+        patch(
+            "custom_components.bookstack_sync.coordinator.run_sync",
+            new=AsyncMock(side_effect=BookStackApiAuthError("token rotated")),
+        ),
+        pytest.raises(ConfigEntryAuthFailed),
+    ):
+        await coord._async_update_data()
+
+
+async def test_last_run_recorded_after_successful_sync(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    config_entry.add_to_hass(hass)
+    coord = _make_coordinator(hass, config_entry)
+    config_entry.runtime_data = type(
+        "RD",
+        (),
+        {"client": object(), "store": object()},
+    )()
+    report = SyncReport()
+
+    with patch(
+        "custom_components.bookstack_sync.coordinator.run_sync",
+        new=AsyncMock(return_value=report),
+    ):
+        await coord.async_run_sync()
+
+    assert coord.last_run is not None
+    assert coord.last_report is report
+
+
+async def test_dry_run_does_not_record_last_run(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    config_entry.add_to_hass(hass)
+    coord = _make_coordinator(hass, config_entry)
+    config_entry.runtime_data = type(
+        "RD",
+        (),
+        {"client": object(), "store": object()},
+    )()
+
+    with patch(
+        "custom_components.bookstack_sync.coordinator.run_sync",
+        new=AsyncMock(return_value=SyncReport(dry_run=True)),
+    ):
+        await coord.async_run_sync(dry_run=True)
+
+    assert coord.last_run is None
+    assert coord.last_report is None

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,152 @@
+"""Tests for the HA-registry extractor.
+
+Uses pytest-homeassistant-custom-component's hass fixture to drive a
+real (in-memory) HA core. We populate the area / device / entity
+registries plus a few fake states and assert that ``extract_snapshot``
+produces the expected sorted, filtered structure.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers import (
+    area_registry as ar,
+)
+from homeassistant.helpers import (
+    device_registry as dr,
+)
+from homeassistant.helpers import (
+    entity_registry as er,
+)
+
+from custom_components.bookstack_sync.extractor import extract_snapshot
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+async def _seed_minimal_registry(hass: HomeAssistant) -> None:
+    """Two areas, two devices each, a handful of entities + automation/script/scene."""
+    area_reg = ar.async_get(hass)
+    living = area_reg.async_create("Living Room")
+    kitchen = area_reg.async_create("Kitchen")
+
+    device_reg = dr.async_get(hass)
+    sofa = device_reg.async_get_or_create(
+        config_entry_id="entry1",
+        identifiers={("mqtt", "sofa")},
+        name="Sofa Light",
+        manufacturer="Philips",
+        model="Hue",
+        sw_version="2.1",
+    )
+    device_reg.async_update_device(sofa.id, area_id=living.id)
+
+    fridge = device_reg.async_get_or_create(
+        config_entry_id="entry2",
+        identifiers={("zigbee", "fridge")},
+        name="Fridge Door",
+        manufacturer="Acme",
+        model="DoorSensor",
+    )
+    device_reg.async_update_device(fridge.id, area_id=kitchen.id)
+
+    entity_reg = er.async_get(hass)
+    entity_reg.async_get_or_create(
+        domain="light",
+        platform="hue",
+        unique_id="sofa_light",
+        device_id=sofa.id,
+        suggested_object_id="sofa_light",
+    )
+    hass.states.async_set("light.sofa_light", "on", {"friendly_name": "Sofa Light"})
+
+    # State for an automation we want exported.
+    hass.states.async_set(
+        "automation.morning",
+        "on",
+        {
+            "friendly_name": "Morning Routine",
+            "description": "Turn on lights at sunrise",
+            "mode": "single",
+            "last_triggered": None,
+        },
+    )
+    hass.states.async_set(
+        "script.welcome",
+        "off",
+        {"friendly_name": "Welcome", "description": "Say hello"},
+    )
+    hass.states.async_set("scene.cinema", "scening", {"friendly_name": "Cinema"})
+
+
+async def test_extract_snapshot_basic_shape(hass: HomeAssistant) -> None:
+    await _seed_minimal_registry(hass)
+    snap = extract_snapshot(hass)
+
+    area_names = [a.name for a in snap.areas]
+    assert "Kitchen" in area_names
+    assert "Living Room" in area_names
+    # Sorted alphabetically (case-insensitive)
+    assert area_names == sorted(area_names, key=str.lower)
+
+    automation_names = [a.name for a in snap.automations]
+    assert "Morning Routine" in automation_names
+    morning = next(a for a in snap.automations if a.name == "Morning Routine")
+    assert morning.description == "Turn on lights at sunrise"
+    assert morning.mode == "single"
+
+    script_names = [s.name for s in snap.scripts]
+    assert "Welcome" in script_names
+
+    scene_names = [s.name for s in snap.scenes]
+    assert "Cinema" in scene_names
+
+
+async def test_extract_snapshot_excluded_area_drops_devices(
+    hass: HomeAssistant,
+) -> None:
+    await _seed_minimal_registry(hass)
+    area_reg = ar.async_get(hass)
+    kitchen = next(a for a in area_reg.areas.values() if a.name == "Kitchen")
+
+    snap = extract_snapshot(hass, excluded_area_ids=[kitchen.id])
+
+    area_names = [a.name for a in snap.areas]
+    assert "Kitchen" not in area_names
+    assert "Living Room" in area_names
+
+    # The fridge device was assigned to Kitchen, so it must be filtered out.
+    all_devices = [d.name for area in snap.areas for d in area.devices]
+    all_devices += [d.name for d in snap.unassigned_devices]
+    assert "Fridge Door" not in all_devices
+
+
+async def test_mqtt_topic_extracted_from_state_attributes(
+    hass: HomeAssistant,
+) -> None:
+    await _seed_minimal_registry(hass)
+    # Override the state to include an MQTT topic
+    hass.states.async_set(
+        "light.sofa_light",
+        "on",
+        {
+            "friendly_name": "Sofa Light",
+            "topic": "tasmota/sofa/STATE",
+        },
+    )
+    snap = extract_snapshot(hass)
+    living = next(a for a in snap.areas if a.name == "Living Room")
+    sofa = next(d for d in living.devices if d.name == "Sofa Light")
+    sofa_entity = next(e for e in sofa.entities if e.entity_id == "light.sofa_light")
+    assert sofa_entity.mqtt_topic == "tasmota/sofa/STATE"
+
+
+async def test_extract_addons_returns_empty_without_supervisor(
+    hass: HomeAssistant,
+) -> None:
+    # In test environment there's no Supervisor available, so add-ons
+    # should be an empty list (not raise).
+    snap = extract_snapshot(hass)
+    assert snap.addons == []

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -19,6 +19,7 @@ from homeassistant.helpers import (
 from homeassistant.helpers import (
     entity_registry as er,
 )
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.bookstack_sync.extractor import extract_snapshot
 
@@ -28,6 +29,13 @@ if TYPE_CHECKING:
 
 async def _seed_minimal_registry(hass: HomeAssistant) -> None:
     """Two areas, two devices each, a handful of entities + automation/script/scene."""
+    # Devices in HA's registry must reference real config entries, so create
+    # placeholder entries first.
+    entry1 = MockConfigEntry(domain="mqtt", entry_id="entry1", title="MQTT")
+    entry2 = MockConfigEntry(domain="zha", entry_id="entry2", title="Zigbee")
+    entry1.add_to_hass(hass)
+    entry2.add_to_hass(hass)
+
     area_reg = ar.async_get(hass)
     living = area_reg.async_create("Living Room")
     kitchen = area_reg.async_create("Kitchen")

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,155 @@
+"""Tests for the marker-block merge logic.
+
+These exercise the bug paths we hit in v0.2.0 / v0.2.1 (false-positive
+tampering due to hash asymmetry) plus the round-trip property: rendering
+through ``build_page_body`` and reading back via ``extract_auto_block``
+must produce a string whose hash matches the stored hash.
+"""
+
+from __future__ import annotations
+
+from custom_components.bookstack_sync.const import (
+    AUTO_BEGIN_MARKER,
+    AUTO_END_MARKER,
+    MANUAL_BEGIN_MARKER,
+    MANUAL_END_MARKER,
+)
+from custom_components.bookstack_sync.merge import (
+    _legacy_unstripped_hash,
+    build_page_body,
+    extract_auto_block,
+    extract_manual_block,
+    hash_auto_block,
+    merge_page,
+)
+
+
+class TestHashAutoBlock:
+    """Hash must be whitespace-normalised (write/read symmetric)."""
+
+    def test_hash_is_strip_invariant(self) -> None:
+        # Regression: this was the v0.2.0 bug. Renderer output ended with
+        # "\n", build_page_body stripped it. Hashes were computed over
+        # different bytes -> false tampering.
+        assert hash_auto_block("hello") == hash_auto_block("hello\n")
+        assert hash_auto_block("hello") == hash_auto_block("\n\nhello\n\n")
+        assert hash_auto_block("hello") == hash_auto_block("hello   ")
+
+    def test_different_content_hashes_differently(self) -> None:
+        assert hash_auto_block("hello") != hash_auto_block("world")
+
+    def test_empty_string_is_stable(self) -> None:
+        assert hash_auto_block("") == hash_auto_block("\n")
+        assert hash_auto_block("") == hash_auto_block("   ")
+
+
+class TestRoundTrip:
+    """build_page_body + extract_auto_block must round-trip the AUTO body."""
+
+    def test_basic_round_trip(self) -> None:
+        body = "Some markdown content\nwith two lines"
+        full = build_page_body(body, "")
+        extracted = extract_auto_block(full)
+        assert extracted == body
+
+    def test_round_trip_preserves_hash(self) -> None:
+        # Regression v0.2.1: the hash computed at write time must match the
+        # hash computed when reading back from the same page body.
+        body = "Auto content\nwith trailing newline\n"
+        full = build_page_body(body, "")
+        extracted = extract_auto_block(full)
+        assert hash_auto_block(body) == hash_auto_block(extracted)
+
+    def test_manual_block_preserved(self) -> None:
+        manual = "User notes\n- bullet\n- another"
+        full = build_page_body("auto", manual)
+        assert extract_manual_block(full) == manual
+
+    def test_extract_returns_none_when_marker_missing(self) -> None:
+        assert extract_auto_block("no markers here") is None
+        assert extract_manual_block("no markers here") is None
+
+    def test_extract_returns_none_for_empty_input(self) -> None:
+        assert extract_auto_block(None) is None
+        assert extract_auto_block("") is None
+        assert extract_manual_block(None) is None
+        assert extract_manual_block("") is None
+
+
+class TestMergePage:
+    """End-to-end merge behaviour."""
+
+    def test_first_write_yields_default_manual(self) -> None:
+        # No existing markdown means new page; default manual is generated.
+        result = merge_page(
+            "auto body", existing_markdown=None, last_known_auto_hash=None
+        )
+        assert AUTO_BEGIN_MARKER in result.body
+        assert AUTO_END_MARKER in result.body
+        assert MANUAL_BEGIN_MARKER in result.body
+        assert MANUAL_END_MARKER in result.body
+        assert "auto body" in result.body
+        assert result.manual_block_tampered is False
+        assert result.auto_block_changed is True
+
+    def test_unchanged_auto_with_matching_hash(self) -> None:
+        body = "auto content"
+        existing_full = build_page_body(body, "user notes")
+        result = merge_page(
+            new_auto_body=body,
+            existing_markdown=existing_full,
+            last_known_auto_hash=hash_auto_block(body),
+        )
+        assert result.manual_block_tampered is False
+        assert result.auto_block_changed is False
+        # Manual block must survive verbatim
+        assert "user notes" in result.body
+
+    def test_tampered_when_existing_auto_modified(self) -> None:
+        original = "v1 auto content"
+        tampered = "MAN-EDITED auto content"
+        existing_full = build_page_body(tampered, "user notes")
+        result = merge_page(
+            new_auto_body="v2 auto content",
+            existing_markdown=existing_full,
+            # last_known_hash is for the original (v1), not the tampered version
+            last_known_auto_hash=hash_auto_block(original),
+        )
+        assert result.manual_block_tampered is True
+
+    def test_legacy_unstripped_hash_does_not_trigger_tampered(self) -> None:
+        # Regression v0.2.1: setups upgrading from v0.1.x have stored hashes
+        # of unstripped bodies. The new tampered check must accept the legacy
+        # variant so existing pages don't show as tampered after upgrade.
+        body = "auto with trailing\n"
+        existing_full = build_page_body(body, "user notes")
+        legacy_hash = _legacy_unstripped_hash(body)
+        result = merge_page(
+            new_auto_body=body,
+            existing_markdown=existing_full,
+            last_known_auto_hash=legacy_hash,
+        )
+        assert result.manual_block_tampered is False
+
+    def test_legacy_unstripped_no_newline_variant_also_accepted(self) -> None:
+        # Some renderers (the v0.1.x overview) produced output WITHOUT a
+        # trailing newline. Their stored legacy hash is just hash(body).
+        body = "auto without trailing"
+        existing_full = build_page_body(body, "user notes")
+        legacy_hash = _legacy_unstripped_hash(body)
+        result = merge_page(
+            new_auto_body=body,
+            existing_markdown=existing_full,
+            last_known_auto_hash=legacy_hash,
+        )
+        assert result.manual_block_tampered is False
+
+    def test_no_last_known_hash_means_not_tampered(self) -> None:
+        # First sync: no last_known_hash, can't be tampered.
+        existing_full = build_page_body("auto", "user notes")
+        result = merge_page(
+            new_auto_body="auto",
+            existing_markdown=existing_full,
+            last_known_auto_hash=None,
+        )
+        assert result.manual_block_tampered is False

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,0 +1,330 @@
+"""Tests for the deterministic markdown renderer.
+
+The renderer's whole point is byte-identical output for unchanged input,
+so the renderer-determinism property is the first thing we lock down.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+from custom_components.bookstack_sync.extractor import (
+    AddonSnapshot,
+    AreaSnapshot,
+    AutomationSnapshot,
+    DeviceSnapshot,
+    EntitySnapshot,
+    HASnapshot,
+    IntegrationSnapshot,
+    SceneSnapshot,
+    ScriptSnapshot,
+)
+from custom_components.bookstack_sync.renderer import (
+    _md_escape,
+    render_addons_auto_block,
+    render_area_auto_block,
+    render_automations_auto_block,
+    render_device_auto_block,
+    render_integrations_auto_block,
+    render_overview_auto_block,
+    render_scenes_auto_block,
+    render_scripts_auto_block,
+    render_tombstone_auto_block,
+)
+
+# ---------------------------------------------------------------------------
+# helpers
+
+
+def _entity(entity_id: str = "sensor.x", *, name: str = "X") -> EntitySnapshot:
+    return EntitySnapshot(
+        entity_id=entity_id,
+        name=name,
+        platform="mqtt",
+        device_id=None,
+        area_id=None,
+        state="on",
+        attributes={},
+        disabled=False,
+    )
+
+
+def _device(device_id: str = "dev1", *, name: str = "Device 1") -> DeviceSnapshot:
+    return DeviceSnapshot(
+        device_id=device_id,
+        name=name,
+        manufacturer="Acme",
+        model="Model X",
+        sw_version="1.0",
+        hw_version="A",
+        area_id=None,
+        config_entries=("entry1",),
+    )
+
+
+def _empty_snapshot() -> HASnapshot:
+    return HASnapshot(
+        areas=[],
+        unassigned_devices=[],
+        automations=[],
+        scripts=[],
+        scenes=[],
+        integrations=[],
+        addons=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# tests
+
+
+class TestMdEscape:
+    """Markdown-escape util — used to sanitize user-supplied names."""
+
+    def test_pipe_escaped(self) -> None:
+        assert _md_escape("a|b") == r"a\|b"
+
+    def test_backslash_escaped_first(self) -> None:
+        # Backslash must be escaped BEFORE pipe so we don't double-escape
+        # a backslash that escaped a pipe.
+        assert _md_escape("a\\b") == r"a\\b"
+
+    def test_html_brackets_replaced(self) -> None:
+        assert _md_escape("<script>") == "&lt;script&gt;"
+
+    def test_newline_replaced_with_space(self) -> None:
+        assert _md_escape("a\nb") == "a b"
+
+    def test_empty_input(self) -> None:
+        assert _md_escape("") == ""
+
+    def test_no_special_chars_unchanged(self) -> None:
+        assert _md_escape("Living Room") == "Living Room"
+
+
+class TestDeterminism:
+    """Same input must produce byte-identical output across calls."""
+
+    def test_overview_is_deterministic(self, fixed_now: datetime) -> None:
+        snap = _empty_snapshot()
+        first = render_overview_auto_block(snap, fixed_now)
+        second = render_overview_auto_block(snap, fixed_now)
+        assert first == second
+
+    def test_area_is_deterministic(self, fixed_now: datetime) -> None:
+        area = AreaSnapshot(
+            area_id="living",
+            name="Living Room",
+            devices=[_device("d1"), _device("d2")],
+            orphan_entities=[],
+        )
+        first = render_area_auto_block(area, fixed_now)
+        second = render_area_auto_block(area, fixed_now)
+        assert first == second
+
+    def test_device_is_deterministic(self, fixed_now: datetime) -> None:
+        device = _device(name="Tasmota Plug")
+        device.entities.extend([_entity("switch.a"), _entity("sensor.b")])
+        first = render_device_auto_block(device, fixed_now)
+        second = render_device_auto_block(device, fixed_now)
+        assert first == second
+
+
+class TestOverviewLinks:
+    """Overview must use BookStack page-link syntax when ids are provided."""
+
+    def test_area_link_rendered(self, fixed_now: datetime) -> None:
+        area = AreaSnapshot(area_id="living", name="Living Room")
+        snap = _empty_snapshot()
+        snap.areas.append(area)
+        out = render_overview_auto_block(
+            snap,
+            fixed_now,
+            page_links={"area:living": 42},
+        )
+        assert "[Living Room](page:42)" in out
+
+    def test_area_falls_back_to_bold_when_no_link(self, fixed_now: datetime) -> None:
+        area = AreaSnapshot(area_id="living", name="Living Room")
+        snap = _empty_snapshot()
+        snap.areas.append(area)
+        out = render_overview_auto_block(snap, fixed_now)
+        assert "**Living Room**" in out
+        assert "page:" not in out
+
+    def test_bundle_links_rendered(self, fixed_now: datetime) -> None:
+        snap = _empty_snapshot()
+        out = render_overview_auto_block(
+            snap,
+            fixed_now,
+            page_links={
+                "integrations:_": 1,
+                "automations:_": 2,
+                "scripts:_": 3,
+                "scenes:_": 4,
+                "addons:_": 5,
+            },
+        )
+        assert "[Integrationen](page:1)" in out
+        assert "[Automatisierungen](page:2)" in out
+        assert "[Skripte](page:3)" in out
+        assert "[Szenen](page:4)" in out
+        assert "[Add-ons](page:5)" in out
+
+    def test_special_chars_in_area_name_escaped(self, fixed_now: datetime) -> None:
+        # Names like "Wohn|zimmer <stage>" must not break the markdown table.
+        area = AreaSnapshot(area_id="living", name="Wohn|zimmer <stage>")
+        snap = _empty_snapshot()
+        snap.areas.append(area)
+        out = render_overview_auto_block(
+            snap,
+            fixed_now,
+            page_links={"area:living": 99},
+        )
+        assert r"Wohn\|zimmer &lt;stage&gt;" in out
+
+
+class TestBundlePages:
+    """The five bundle-list renderers."""
+
+    def test_automations_with_description_rendered_as_quote(
+        self,
+        fixed_now: datetime,
+    ) -> None:
+        autos = [
+            AutomationSnapshot(
+                entity_id="automation.foo",
+                name="Foo",
+                description="Wakes me up",
+                state="on",
+                mode="single",
+                last_triggered="2026-04-28T06:00:00+00:00",
+            ),
+        ]
+        out = render_automations_auto_block(autos, fixed_now)
+        assert "### Foo" in out
+        assert "`automation.foo`" in out
+        assert "> Wakes me up" in out
+
+    def test_empty_automations_emits_placeholder(self, fixed_now: datetime) -> None:
+        out = render_automations_auto_block([], fixed_now)
+        assert "Keine Automatisierungen" in out
+
+    def test_scripts_use_md_escape_for_name(self, fixed_now: datetime) -> None:
+        scripts = [
+            ScriptSnapshot(
+                entity_id="script.foo",
+                name="Foo|Bar",
+                description=None,
+                state=None,
+                last_triggered=None,
+            ),
+        ]
+        out = render_scripts_auto_block(scripts, fixed_now)
+        assert r"### Foo\|Bar" in out
+
+    def test_scenes_table_format(self, fixed_now: datetime) -> None:
+        scenes = [SceneSnapshot(entity_id="scene.bedtime", name="Bedtime")]
+        out = render_scenes_auto_block(scenes, fixed_now)
+        assert "**Bedtime**" in out
+        assert "`scene.bedtime`" in out
+
+    def test_integrations_table_columns_present(self, fixed_now: datetime) -> None:
+        integ = [
+            IntegrationSnapshot(
+                entry_id="abc",
+                domain="mqtt",
+                title="MQTT Broker",
+                state="loaded",
+                source="user",
+                device_count=12,
+                entity_count=42,
+            ),
+        ]
+        out = render_integrations_auto_block(integ, fixed_now)
+        assert "`mqtt`" in out
+        assert "MQTT Broker" in out
+        assert "loaded" in out
+        assert "12" in out
+        assert "42" in out
+
+    def test_addons_table(self, fixed_now: datetime) -> None:
+        addons = [
+            AddonSnapshot(
+                slug="core_zwave",
+                name="Z-Wave",
+                version="1.2.3",
+                state="started",
+                update_available=True,
+            ),
+        ]
+        out = render_addons_auto_block(addons, fixed_now)
+        assert "`core_zwave`" in out
+        assert "Z-Wave" in out
+        assert "1.2.3" in out
+        assert "started" in out
+        assert "Ja" in out
+
+    def test_no_addons_emits_supervisor_placeholder(self, fixed_now: datetime) -> None:
+        out = render_addons_auto_block([], fixed_now)
+        assert "Kein Supervisor" in out
+
+
+class TestTombstone:
+    """Tombstone-block has the obvious warning + date format."""
+
+    def test_tombstone_contains_date(self, fixed_now: datetime) -> None:
+        out = render_tombstone_auto_block(fixed_now)
+        assert "2026-04-28" in out
+
+    def test_tombstone_has_warning_header(self, fixed_now: datetime) -> None:
+        out = render_tombstone_auto_block(fixed_now)
+        assert "verwaist" in out
+
+
+class TestEntityLinesMqttTopic:
+    """MQTT topic should be surfaced when present in the entity attributes."""
+
+    def test_mqtt_topic_rendered_when_present(self, fixed_now: datetime) -> None:
+        device = _device()
+        entity = _entity()
+        entity.mqtt_topic = "tasmota/plug3/STATE"
+        device.entities.append(entity)
+        out = render_device_auto_block(device, fixed_now)
+        assert "(Topic: `tasmota/plug3/STATE`)" in out
+
+    def test_no_topic_means_no_topic_marker(self, fixed_now: datetime) -> None:
+        device = _device()
+        device.entities.append(_entity())
+        out = render_device_auto_block(device, fixed_now)
+        assert "Topic" not in out
+
+
+@pytest.mark.parametrize(
+    "render_fn",
+    [
+        render_overview_auto_block,
+        render_area_auto_block,
+        render_device_auto_block,
+    ],
+)
+def test_all_renderers_include_attribution(
+    render_fn: object,
+    fixed_now: datetime,
+) -> None:
+    """Every page is timestamped + attributed - verifies _format_attribution path."""
+    if render_fn is render_overview_auto_block:
+        out = render_overview_auto_block(_empty_snapshot(), fixed_now)
+    elif render_fn is render_area_auto_block:
+        out = render_area_auto_block(
+            AreaSnapshot(area_id="x", name="X"),
+            fixed_now,
+        )
+    else:
+        out = render_device_auto_block(_device(), fixed_now)
+    assert "Stand 2026-04-28 12:00 UTC" in out

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,182 @@
+"""End-to-end tests for the sync orchestrator.
+
+We mock the BookStackApiClient (not the lower aiohttp layer) so these
+tests focus on the orchestration: chapter creation, two-pass overview
+rendering, tombstoning, page mapping persistence.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.helpers import (
+    area_registry as ar,
+)
+
+from custom_components.bookstack_sync.const import (
+    CHAPTER_KEY_AREAS,
+    CHAPTER_KEY_DEVICES,
+    CHAPTER_TITLE_AREAS,
+    CHAPTER_TITLE_DEVICES,
+)
+from custom_components.bookstack_sync.store import BookStackSyncStore
+from custom_components.bookstack_sync.sync import run_sync
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+def _fake_client_with_state(state: dict[str, Any]) -> MagicMock:
+    """A MagicMock that mimics BookStackApiClient and tracks created pages.
+
+    state['next_id'] is incremented on every page/chapter create so we
+    hand out unique IDs without colliding.
+    """
+    state.setdefault("pages", {})  # id -> {markdown, chapter_id, name}
+    state.setdefault("chapters", {})  # id -> name
+    state.setdefault("next_id", 100)
+
+    client = MagicMock()
+
+    async def list_chapters(book_id: int) -> list[dict[str, Any]]:
+        return [{"id": cid, "name": name} for cid, name in state["chapters"].items()]
+
+    async def create_chapter(
+        book_id: int,
+        name: str,
+        description: str | None = None,
+    ) -> dict[str, Any]:
+        cid = state["next_id"]
+        state["next_id"] += 1
+        state["chapters"][cid] = name
+        return {"id": cid, "name": name}
+
+    async def create_page(
+        name: str,
+        markdown: str,
+        *,
+        book_id: int | None = None,
+        chapter_id: int | None = None,
+    ) -> dict[str, Any]:
+        pid = state["next_id"]
+        state["next_id"] += 1
+        state["pages"][pid] = {
+            "id": pid,
+            "name": name,
+            "markdown": markdown,
+            "chapter_id": chapter_id,
+            "book_id": book_id,
+        }
+        return state["pages"][pid]
+
+    async def get_page(page_id: int) -> dict[str, Any]:
+        return state["pages"][page_id]
+
+    async def update_page(
+        page_id: int,
+        name: str,
+        markdown: str,
+        *,
+        chapter_id: int | None = None,
+    ) -> dict[str, Any]:
+        state["pages"][page_id]["name"] = name
+        state["pages"][page_id]["markdown"] = markdown
+        if chapter_id is not None:
+            state["pages"][page_id]["chapter_id"] = chapter_id
+        return state["pages"][page_id]
+
+    client.list_chapters = AsyncMock(side_effect=list_chapters)
+    client.create_chapter = AsyncMock(side_effect=create_chapter)
+    client.create_page = AsyncMock(side_effect=create_page)
+    client.get_page = AsyncMock(side_effect=get_page)
+    client.update_page = AsyncMock(side_effect=update_page)
+    return client
+
+
+@pytest.fixture
+async def store(hass: HomeAssistant) -> BookStackSyncStore:
+    s = BookStackSyncStore(hass, entry_id="testentry")
+    await s.async_load()
+    return s
+
+
+async def test_first_sync_creates_chapters_and_pages(
+    hass: HomeAssistant,
+    store: BookStackSyncStore,
+) -> None:
+    state: dict[str, Any] = {}
+    client = _fake_client_with_state(state)
+
+    # Seed minimal HA state
+    area_reg = ar.async_get(hass)
+    area_reg.async_create("Living Room")
+
+    report = await run_sync(hass, client, store, book_id=1)
+
+    # Both chapters auto-created
+    assert CHAPTER_TITLE_AREAS in state["chapters"].values()
+    assert CHAPTER_TITLE_DEVICES in state["chapters"].values()
+    assert store.get_chapter(CHAPTER_KEY_AREAS) is not None
+    assert store.get_chapter(CHAPTER_KEY_DEVICES) is not None
+
+    # At least the overview + the four bundle pages + the area page were created
+    assert len(report.created) >= 6
+    assert report.errors == []
+
+
+async def test_second_sync_with_unchanged_data_makes_no_changes(
+    hass: HomeAssistant,
+    store: BookStackSyncStore,
+) -> None:
+    state: dict[str, Any] = {}
+    client = _fake_client_with_state(state)
+    area_reg = ar.async_get(hass)
+    area_reg.async_create("Living Room")
+
+    # First sync: creates everything
+    await run_sync(hass, client, store, book_id=1)
+
+    # Second sync should be all-unchanged (this is the regression hot spot
+    # we just fixed in v0.2.1: false-positive tampering after first write).
+    report2 = await run_sync(hass, client, store, book_id=1)
+    assert report2.created == []
+    assert report2.skipped_conflict == []  # NO false positives
+    assert report2.errors == []
+
+
+async def test_dry_run_does_not_call_writes(
+    hass: HomeAssistant,
+    store: BookStackSyncStore,
+) -> None:
+    state: dict[str, Any] = {}
+    client = _fake_client_with_state(state)
+
+    report = await run_sync(hass, client, store, book_id=1, dry_run=True)
+    assert report.dry_run is True
+    client.create_page.assert_not_called()
+    client.update_page.assert_not_called()
+    client.create_chapter.assert_not_called()
+
+
+async def test_chapter_reused_when_already_present(
+    hass: HomeAssistant,
+    store: BookStackSyncStore,
+) -> None:
+    # Seed BookStack with an existing "Räume" chapter from a previous setup.
+    state: dict[str, Any] = {
+        "chapters": {500: CHAPTER_TITLE_AREAS},
+        "next_id": 600,
+    }
+    client = _fake_client_with_state(state)
+
+    await run_sync(hass, client, store, book_id=1)
+
+    # We must NOT have created a duplicate "Räume" chapter — only
+    # "Geräte" was missing.
+    chapter_titles = list(state["chapters"].values())
+    assert chapter_titles.count(CHAPTER_TITLE_AREAS) == 1
+    assert chapter_titles.count(CHAPTER_TITLE_DEVICES) == 1
+    # Stored mapping points at the pre-existing chapter id (500), not a new one.
+    assert store.get_chapter(CHAPTER_KEY_AREAS) == 500


### PR DESCRIPTION
Adds the test infrastructure missing since V0. Three recent regressions (.1.2 chunked-transfer, .2.1 hash-asymmetry, .2.2 transient retry / log spam) all have explicit regression tests now.

## Files
- 7 test files under tests/ - merge, renderer, api, extractor, config_flow, coordinator, sync
- requirements-test.txt with pinned versions
- pytest.ini
- .github/workflows/test.yml
- .ruff.toml per-file-ignores for tests/

## Coverage
- Stufe 1 (pure logic, no HA framework): merge, renderer, api
- Stufe 2 (uses pytest-homeassistant-custom-component): extractor, config_flow, coordinator, sync

## What does not change

No production code changes (other than the manifest version bump). v0.2.2 behaviour is preserved; tests describe the current contract.