### PR TITLE
v0.4.0 - Output i18n (DE+EN) + cleaner titles + chapter-migration robustness

### DIFF
--- a/custom_components/bookstack_sync/_strings.py
+++ b/custom_components/bookstack_sync/_strings.py
@@ -1,0 +1,280 @@
+"""
+Localised strings for the BookStack output (page content + notifications).
+
+This is intentionally a separate translation system from HA's own
+``translations/*.json`` files: those localise the integration's UI
+(config flow, sensor names, service descriptions). The strings in this
+module localise what the integration *writes* into BookStack — page
+titles, section headings, table column labels, the tombstone banner,
+the persistent-notification body — so that an English-speaking user
+on an English HA does not end up with a German-only wiki.
+
+Add a new language by adding a fully-populated entry to ``_STRINGS``.
+Falling back to English keeps every renderer call safe even on
+unsupported locales.
+"""
+
+from __future__ import annotations
+
+LANG_DE = "de"
+LANG_EN = "en"
+LANG_DEFAULT = LANG_EN
+
+SUPPORTED_LANGUAGES: tuple[str, ...] = (LANG_DE, LANG_EN)
+
+
+_STRINGS: dict[str, dict[str, str]] = {
+    LANG_DE: {
+        # Attribution + tombstone
+        "attribution_template": ("_{attribution} – Stand {timestamp} UTC._"),
+        "tombstone_attribution_template": (
+            "_{attribution} – letzter Sync {timestamp} UTC._"
+        ),
+        "tombstone_warning": "⚠️ **Diese Seite ist verwaist.**",
+        "tombstone_explanation_template": (
+            "Das zugehörige Objekt existiert seit {date} nicht mehr in Home Assistant."
+        ),
+        "tombstone_manual_hint": (
+            "Der manuelle Block unten bleibt unangetastet. Wenn die "
+            "Notizen dort nicht mehr relevant sind, kannst du diese "
+            "Seite manuell löschen."
+        ),
+        # Default manual-block placeholder
+        "default_manual_body": (
+            "_Notizen, die du hier zwischen den Markern einträgst, "
+            "bleiben beim Sync erhalten._"
+        ),
+        # Page titles
+        "title_overview": "Übersicht",
+        "title_integrations": "Integrationen",
+        "title_automations": "Automatisierungen",
+        "title_scripts": "Skripte",
+        "title_scenes": "Szenen",
+        "title_addons": "Add-ons",
+        "title_area_template": "Raum: {name}",
+        "title_device_template": "Gerät: {name}",
+        # Chapter titles + descriptions
+        "chapter_areas_title": "Räume",
+        "chapter_areas_description": (
+            "Pro Raum eine Page mit den dort angesiedelten Geräten und Entities."
+        ),
+        "chapter_devices_title": "Geräte",
+        "chapter_devices_description": (
+            "Pro Gerät eine Page mit Stammdaten und allen zugehörigen Entities."
+        ),
+        # Section headings
+        "section_statistics": "Statistik",
+        "section_areas": "Räume",
+        "section_categories": "Bereiche",
+        "section_unassigned_devices": "Geräte ohne Raum-Zuordnung",
+        "section_devices_in_area_template": "Geräte in {name}",
+        "section_orphan_entities": "Entities ohne Geräte-Zuordnung",
+        "section_master_data": "Stammdaten",
+        "section_entities": "Entities",
+        "section_addons_count_template": "Add-ons ({count})",
+        "section_automations_count_template": "Automatisierungen ({count})",
+        "section_scripts_count_template": "Skripte ({count})",
+        "section_scenes_count_template": "Szenen ({count})",
+        "section_integrations_count_template": "Integrationen ({count})",
+        # Stats list labels (Übersicht)
+        "stat_areas": "Areas",
+        "stat_devices": "Geräte",
+        "stat_entities": "Entities",
+        "stat_integrations": "Integrationen",
+        "stat_automations": "Automatisierungen",
+        "stat_scripts": "Skripte",
+        "stat_scenes": "Szenen",
+        "stat_addons": "Add-ons",
+        # Bundle-link labels (Übersicht "Bereiche" list)
+        "bundle_integrations": "Integrationen",
+        "bundle_automations": "Automatisierungen",
+        "bundle_scripts": "Skripte",
+        "bundle_scenes": "Szenen",
+        "bundle_addons": "Add-ons",
+        # Empty-state messages
+        "empty_areas": "_Keine Areas konfiguriert._",
+        "empty_devices_in_room": "_Keine Geräte in diesem Raum._",
+        "empty_entities_in_device": "_Keine Entities zu diesem Gerät._",
+        "empty_automations": "_Keine Automatisierungen vorhanden._",
+        "empty_scripts": "_Keine Skripte vorhanden._",
+        "empty_scenes": "_Keine Szenen vorhanden._",
+        "empty_integrations": "_Keine Integrationen geladen._",
+        "empty_addons": ("_Kein Supervisor verfügbar oder keine Add-ons installiert._"),
+        # Device facts table
+        "field_manufacturer": "Hersteller",
+        "field_model": "Modell",
+        "field_firmware": "Firmware",
+        "field_hardware": "Hardware",
+        "field_integrations": "Integrationen",
+        "field_device_id": "Device-ID",
+        "table_field_header": "Feld",
+        "table_value_header": "Wert",
+        # Addon table
+        "addon_col_name": "Add-on",
+        "addon_col_slug": "Slug",
+        "addon_col_version": "Version",
+        "addon_col_state": "Status",
+        "addon_col_update": "Update",
+        "addon_update_yes": "Ja",
+        "addon_update_no": "nein",
+        # Integration table
+        "integration_col_name": "Integration",
+        "integration_col_title": "Titel",
+        "integration_col_state": "Status",
+        "integration_col_source": "Quelle",
+        "integration_col_devices": "Geräte",
+        "integration_col_entities": "Entities",
+        # Entity-line bits
+        "entity_state_label": "State",
+        "entity_topic_label": "Topic",
+        "entity_disabled_marker": "_[disabled]_",
+        # Automation/Script details
+        "field_entity": "Entity",
+        "field_status": "Status",
+        "field_mode": "Modus",
+        "field_last_triggered": "Letzter Trigger",
+        # Bold / heading prefixes
+        "label_entities": "Entities",
+        # Notification
+        "notification_title": "BookStack Sync",
+        "notification_body_template": (
+            "BookStack-Sync abgeschlossen:\n\n"
+            "- {created} angelegt\n"
+            "- {updated} aktualisiert\n"
+            "- {unchanged} unverändert\n"
+            "- {tombstoned} verwaist (Tombstone)\n"
+            "- {skipped} mit Konflikt übersprungen\n"
+            "- {errors} Fehler"
+        ),
+    },
+    LANG_EN: {
+        "attribution_template": ("_{attribution} – synced at {timestamp} UTC._"),
+        "tombstone_attribution_template": (
+            "_{attribution} – last sync {timestamp} UTC._"
+        ),
+        "tombstone_warning": "⚠️ **This page is orphaned.**",
+        "tombstone_explanation_template": (
+            "The associated object no longer exists in Home Assistant since {date}."
+        ),
+        "tombstone_manual_hint": (
+            "The manual block below stays untouched. If the notes "
+            "there are no longer relevant you can delete this page "
+            "manually."
+        ),
+        "default_manual_body": (
+            "_Notes you put between the markers here are preserved across syncs._"
+        ),
+        "title_overview": "Overview",
+        "title_integrations": "Integrations",
+        "title_automations": "Automations",
+        "title_scripts": "Scripts",
+        "title_scenes": "Scenes",
+        "title_addons": "Add-ons",
+        "title_area_template": "Area: {name}",
+        "title_device_template": "Device: {name}",
+        "chapter_areas_title": "Areas",
+        "chapter_areas_description": (
+            "One page per area with all the devices and entities located there."
+        ),
+        "chapter_devices_title": "Devices",
+        "chapter_devices_description": (
+            "One page per device with master data and all its entities."
+        ),
+        "section_statistics": "Statistics",
+        "section_areas": "Areas",
+        "section_categories": "Sections",
+        "section_unassigned_devices": "Devices without area",
+        "section_devices_in_area_template": "Devices in {name}",
+        "section_orphan_entities": "Entities without a device",
+        "section_master_data": "Master data",
+        "section_entities": "Entities",
+        "section_addons_count_template": "Add-ons ({count})",
+        "section_automations_count_template": "Automations ({count})",
+        "section_scripts_count_template": "Scripts ({count})",
+        "section_scenes_count_template": "Scenes ({count})",
+        "section_integrations_count_template": "Integrations ({count})",
+        "stat_areas": "Areas",
+        "stat_devices": "Devices",
+        "stat_entities": "Entities",
+        "stat_integrations": "Integrations",
+        "stat_automations": "Automations",
+        "stat_scripts": "Scripts",
+        "stat_scenes": "Scenes",
+        "stat_addons": "Add-ons",
+        "bundle_integrations": "Integrations",
+        "bundle_automations": "Automations",
+        "bundle_scripts": "Scripts",
+        "bundle_scenes": "Scenes",
+        "bundle_addons": "Add-ons",
+        "empty_areas": "_No areas configured._",
+        "empty_devices_in_room": "_No devices in this area._",
+        "empty_entities_in_device": "_No entities on this device._",
+        "empty_automations": "_No automations defined._",
+        "empty_scripts": "_No scripts defined._",
+        "empty_scenes": "_No scenes defined._",
+        "empty_integrations": "_No integrations loaded._",
+        "empty_addons": ("_No Supervisor available or no add-ons installed._"),
+        "field_manufacturer": "Manufacturer",
+        "field_model": "Model",
+        "field_firmware": "Firmware",
+        "field_hardware": "Hardware",
+        "field_integrations": "Integrations",
+        "field_device_id": "Device ID",
+        "table_field_header": "Field",
+        "table_value_header": "Value",
+        "addon_col_name": "Add-on",
+        "addon_col_slug": "Slug",
+        "addon_col_version": "Version",
+        "addon_col_state": "State",
+        "addon_col_update": "Update",
+        "addon_update_yes": "Yes",
+        "addon_update_no": "no",
+        "integration_col_name": "Integration",
+        "integration_col_title": "Title",
+        "integration_col_state": "State",
+        "integration_col_source": "Source",
+        "integration_col_devices": "Devices",
+        "integration_col_entities": "Entities",
+        "entity_state_label": "State",
+        "entity_topic_label": "Topic",
+        "entity_disabled_marker": "_[disabled]_",
+        "field_entity": "Entity",
+        "field_status": "State",
+        "field_mode": "Mode",
+        "field_last_triggered": "Last triggered",
+        "label_entities": "Entities",
+        "notification_title": "BookStack Sync",
+        "notification_body_template": (
+            "BookStack sync complete:\n\n"
+            "- {created} created\n"
+            "- {updated} updated\n"
+            "- {unchanged} unchanged\n"
+            "- {tombstoned} tombstoned\n"
+            "- {skipped} skipped (conflict)\n"
+            "- {errors} errors"
+        ),
+    },
+}
+
+
+def get_strings(lang: str | None) -> dict[str, str]:
+    """
+    Return the translation dict for ``lang``, falling back to English.
+
+    Accepts the bare two-letter code (``"de"``) or longer locale strings
+    (``"de-AT"``, ``"en_GB"``); only the leading two letters are used.
+    """
+    if lang:
+        short = lang.split("-")[0].split("_")[0].lower()
+        if short in _STRINGS:
+            return _STRINGS[short]
+    return _STRINGS[LANG_DEFAULT]
+
+
+def normalise_language(lang: str | None) -> str:
+    """Return the canonical two-letter code we'd resolve ``lang`` to."""
+    if lang:
+        short = lang.split("-")[0].split("_")[0].lower()
+        if short in _STRINGS:
+            return short
+    return LANG_DEFAULT

--- a/custom_components/bookstack_sync/config_flow.py
+++ b/custom_components/bookstack_sync/config_flow.py
@@ -25,17 +25,20 @@ from .const import (
     CONF_BASE_URL,
     CONF_BOOK_ID,
     CONF_EXCLUDED_AREAS,
+    CONF_OUTPUT_LANGUAGE,
     CONF_SYNC_INTERVAL,
     CONF_TOKEN_ID,
     CONF_TOKEN_SECRET,
     CONF_VERIFY_SSL,
     DEFAULT_INTERVAL,
+    DEFAULT_OUTPUT_LANGUAGE,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
     INTERVAL_DAILY,
     INTERVAL_HOURLY,
     INTERVAL_MANUAL,
     LOGGER,
+    OUTPUT_LANGUAGE_AUTO,
 )
 
 
@@ -45,6 +48,16 @@ def _interval_selector() -> selector.SelectSelector:
             mode=selector.SelectSelectorMode.DROPDOWN,
             translation_key="sync_interval",
             options=[INTERVAL_HOURLY, INTERVAL_DAILY, INTERVAL_MANUAL],
+        ),
+    )
+
+
+def _output_language_selector() -> selector.SelectSelector:
+    return selector.SelectSelector(
+        selector.SelectSelectorConfig(
+            mode=selector.SelectSelectorMode.DROPDOWN,
+            translation_key="output_language",
+            options=[OUTPUT_LANGUAGE_AUTO, "de", "en"],
         ),
     )
 
@@ -278,6 +291,10 @@ class BookStackSyncOptionsFlow(OptionsFlow):
                     CONF_BOOK_ID: int(user_input[CONF_BOOK_ID]),
                     CONF_SYNC_INTERVAL: user_input[CONF_SYNC_INTERVAL],
                     CONF_EXCLUDED_AREAS: user_input.get(CONF_EXCLUDED_AREAS, []),
+                    CONF_OUTPUT_LANGUAGE: user_input.get(
+                        CONF_OUTPUT_LANGUAGE,
+                        DEFAULT_OUTPUT_LANGUAGE,
+                    ),
                 },
             )
 
@@ -301,6 +318,10 @@ class BookStackSyncOptionsFlow(OptionsFlow):
             DEFAULT_INTERVAL,
         )
         current_excluded = self.config_entry.options.get(CONF_EXCLUDED_AREAS, [])
+        current_language = self.config_entry.options.get(
+            CONF_OUTPUT_LANGUAGE,
+            DEFAULT_OUTPUT_LANGUAGE,
+        )
 
         return self.async_show_form(
             step_id="init",
@@ -331,6 +352,10 @@ class BookStackSyncOptionsFlow(OptionsFlow):
                     ): selector.AreaSelector(
                         selector.AreaSelectorConfig(multiple=True),
                     ),
+                    vol.Required(
+                        CONF_OUTPUT_LANGUAGE,
+                        default=current_language,
+                    ): _output_language_selector(),
                 },
             ),
         )

--- a/custom_components/bookstack_sync/const.py
+++ b/custom_components/bookstack_sync/const.py
@@ -15,8 +15,12 @@ CONF_BOOK_ID = "book_id"
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_VERIFY_SSL = "verify_ssl"
 CONF_EXCLUDED_AREAS = "excluded_areas"
+CONF_OUTPUT_LANGUAGE = "output_language"
 
 DEFAULT_VERIFY_SSL = True
+# "auto" follows hass.config.language; explicit codes ("de", "en") override it
+OUTPUT_LANGUAGE_AUTO = "auto"
+DEFAULT_OUTPUT_LANGUAGE = OUTPUT_LANGUAGE_AUTO
 
 INTERVAL_HOURLY = "hourly"
 INTERVAL_DAILY = "daily"
@@ -48,16 +52,10 @@ PAGE_KIND_INTEGRATIONS = "integrations"
 PAGE_KIND_ADDONS = "addons"
 
 # Chapters group the many area/device pages so the book stays readable.
+# Titles + descriptions come from `_strings.py` so they follow the user's
+# selected output language.
 CHAPTER_KEY_AREAS = "areas"
 CHAPTER_KEY_DEVICES = "devices"
-CHAPTER_TITLE_AREAS = "Räume"
-CHAPTER_TITLE_DEVICES = "Geräte"
-CHAPTER_DESC_AREAS = (
-    "Pro Raum eine Page mit den dort angesiedelten Geräten und Entities."
-)
-CHAPTER_DESC_DEVICES = (
-    "Pro Gerät eine Page mit Stammdaten und allen zugehörigen Entities."
-)
 
 SERVICE_RUN_NOW = "run_now"
 SERVICE_PREVIEW = "preview"

--- a/custom_components/bookstack_sync/coordinator.py
+++ b/custom_components/bookstack_sync/coordinator.py
@@ -9,14 +9,18 @@ from typing import TYPE_CHECKING
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from ._strings import get_strings
 from .api import BookStackApiAuthError, BookStackApiError
 from .const import (
     CONF_BOOK_ID,
     CONF_EXCLUDED_AREAS,
+    CONF_OUTPUT_LANGUAGE,
     CONF_SYNC_INTERVAL,
     DEFAULT_INTERVAL,
+    DEFAULT_OUTPUT_LANGUAGE,
     INTERVAL_MANUAL,
     LOGGER,
+    OUTPUT_LANGUAGE_AUTO,
     SYNC_INTERVALS,
 )
 from .sync import SyncReport, run_sync
@@ -79,11 +83,13 @@ class BookStackSyncCoordinator(DataUpdateCoordinator[SyncReport]):
             # back to data so both layouts work without crashing.
             book_id = int(options.get(CONF_BOOK_ID) or data[CONF_BOOK_ID])
             excluded_areas = options.get(CONF_EXCLUDED_AREAS, []) or []
+            strings = get_strings(self._resolve_output_language())
             report = await run_sync(
                 self.hass,
                 runtime.client,
                 runtime.store,
                 book_id,
+                strings,
                 dry_run=dry_run,
                 excluded_area_ids=excluded_areas,
             )
@@ -91,3 +97,16 @@ class BookStackSyncCoordinator(DataUpdateCoordinator[SyncReport]):
                 self.last_run = datetime.now(tz=UTC)
                 self.last_report = report
             return report
+
+    def _resolve_output_language(self) -> str:
+        """
+        Return the language code to use for BookStack output.
+
+        ``auto`` (default) follows the user's HA UI language. An explicit
+        choice in the options flow (e.g. ``en``, ``de``) overrides it.
+        """
+        options = self.config_entry.options or {}
+        choice = options.get(CONF_OUTPUT_LANGUAGE, DEFAULT_OUTPUT_LANGUAGE)
+        if choice == OUTPUT_LANGUAGE_AUTO:
+            return self.hass.config.language or "en"
+        return choice

--- a/custom_components/bookstack_sync/extractor.py
+++ b/custom_components/bookstack_sync/extractor.py
@@ -167,9 +167,15 @@ def extract_snapshot(
     for device in device_reg.devices.values():
         if device.area_id in excluded:
             continue
+        # Skip stub devices that some integrations leave behind: no name AND
+        # no user-given name. We later filter again on entity-emptiness so
+        # only useful devices land in the wiki.
+        display_name = device.name_by_user or device.name
+        if not display_name:
+            continue
         devices[device.id] = DeviceSnapshot(
             device_id=device.id,
-            name=device.name_by_user or device.name or device.id,
+            name=display_name,
             manufacturer=device.manufacturer,
             model=device.model,
             sw_version=device.sw_version,

--- a/custom_components/bookstack_sync/manifest.json
+++ b/custom_components/bookstack_sync/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dibi73/ha-bookstack-sync/issues",
   "requirements": [],
-  "version": "0.3.0"
+  "version": "0.4.0"
 }

--- a/custom_components/bookstack_sync/renderer.py
+++ b/custom_components/bookstack_sync/renderer.py
@@ -5,6 +5,10 @@ The renderer is intentionally simple string composition rather than Jinja2:
 templates would add an external file dependency for very little gain at this
 size, and string composition makes it trivial to keep output byte-identical
 when nothing changed.
+
+Every public ``render_*`` function takes a ``strings`` mapping (see
+``_strings.get_strings``). The mapping carries every visible text so the
+output language follows the user's choice without changing render code.
 """
 
 from __future__ import annotations
@@ -29,8 +33,11 @@ if TYPE_CHECKING:
     )
 
 
-def _format_attribution(now: datetime) -> str:
-    return f"_{ATTRIBUTION} – Stand {now.strftime('%Y-%m-%d %H:%M')} UTC._"
+def _format_attribution(strings: dict[str, str], now: datetime) -> str:
+    return strings["attribution_template"].format(
+        attribution=ATTRIBUTION,
+        timestamp=now.strftime("%Y-%m-%d %H:%M"),
+    )
 
 
 def _md_escape(value: str) -> str:
@@ -52,39 +59,33 @@ def _md_escape(value: str) -> str:
     )
 
 
-def render_tombstone_auto_block(now: datetime) -> str:
-    """
-    Render the AUTO block for a page whose HA object no longer exists.
-
-    The MANUAL block stays untouched - the tombstone only replaces the AUTO
-    half so that the user's notes remain available for review or deletion.
-    """
+def render_tombstone_auto_block(strings: dict[str, str], now: datetime) -> str:
+    """Render the AUTO block for a page whose HA object no longer exists."""
+    attribution = strings["tombstone_attribution_template"].format(
+        attribution=ATTRIBUTION,
+        timestamp=now.strftime("%Y-%m-%d %H:%M"),
+    )
+    explanation = strings["tombstone_explanation_template"].format(
+        date=now.strftime("%Y-%m-%d"),
+    )
     return (
-        f"_{ATTRIBUTION} – letzter Sync {now.strftime('%Y-%m-%d %H:%M')} UTC._\n"
+        f"{attribution}\n"
         f"\n"
-        f"> ⚠️ **Diese Seite ist verwaist.**\n"
+        f"> {strings['tombstone_warning']}\n"
         f">\n"
-        f"> Das zugehörige Objekt existiert seit {now.strftime('%Y-%m-%d')} "
-        f"nicht mehr in Home Assistant.\n"
+        f"> {explanation}\n"
         f">\n"
-        f"> Der manuelle Block unten bleibt unangetastet. Wenn die Notizen "
-        f"dort nicht mehr relevant sind, kannst du diese Seite manuell "
-        f"löschen.\n"
+        f"> {strings['tombstone_manual_hint']}\n"
     )
 
 
 def render_overview_auto_block(
     snapshot: HASnapshot,
     now: datetime,
+    strings: dict[str, str],
     page_links: dict[str, int] | None = None,
 ) -> str:
-    """
-    Render the AUTO block of the overview page.
-
-    ``page_links`` maps page keys (e.g. ``area:living_room``) to BookStack
-    page IDs. When provided, area names and category links use BookStack's
-    ``[label](page:ID)`` internal-link syntax instead of plain text.
-    """
+    """Render the AUTO block of the overview page (with optional page links)."""
     links = page_links or {}
     total_devices = sum(len(area.devices) for area in snapshot.areas) + len(
         snapshot.unassigned_devices,
@@ -94,29 +95,29 @@ def render_overview_auto_block(
     ) + sum(len(d.entities) for d in snapshot.unassigned_devices)
 
     lines: list[str] = [
-        _format_attribution(now),
+        _format_attribution(strings, now),
         "",
-        "## Statistik",
+        f"## {strings['section_statistics']}",
         "",
-        f"- Areas: **{len(snapshot.areas)}**",
-        f"- Geräte: **{total_devices}**",
-        f"- Entities: **{total_entities}**",
-        f"- Integrationen: **{len(snapshot.integrations)}**",
-        f"- Automatisierungen: **{len(snapshot.automations)}**",
-        f"- Skripte: **{len(snapshot.scripts)}**",
-        f"- Szenen: **{len(snapshot.scenes)}**",
-        f"- Add-ons: **{len(snapshot.addons)}**",
+        f"- {strings['stat_areas']}: **{len(snapshot.areas)}**",
+        f"- {strings['stat_devices']}: **{total_devices}**",
+        f"- {strings['stat_entities']}: **{total_entities}**",
+        f"- {strings['stat_integrations']}: **{len(snapshot.integrations)}**",
+        f"- {strings['stat_automations']}: **{len(snapshot.automations)}**",
+        f"- {strings['stat_scripts']}: **{len(snapshot.scripts)}**",
+        f"- {strings['stat_scenes']}: **{len(snapshot.scenes)}**",
+        f"- {strings['stat_addons']}: **{len(snapshot.addons)}**",
         "",
-        "## Bereiche",
+        f"## {strings['section_categories']}",
         "",
     ]
-    bundle_links = [
-        ("integrations:_", "Integrationen"),
-        ("automations:_", "Automatisierungen"),
-        ("scripts:_", "Skripte"),
-        ("scenes:_", "Szenen"),
-        ("addons:_", "Add-ons"),
-    ]
+    bundle_links = (
+        ("integrations:_", strings["bundle_integrations"]),
+        ("automations:_", strings["bundle_automations"]),
+        ("scripts:_", strings["bundle_scripts"]),
+        ("scenes:_", strings["bundle_scenes"]),
+        ("addons:_", strings["bundle_addons"]),
+    )
     for key, label in bundle_links:
         page_id = links.get(key)
         if page_id is not None:
@@ -124,7 +125,7 @@ def render_overview_auto_block(
         else:
             lines.append(f"- {label}")
 
-    lines.extend(["", "## Räume", ""])
+    lines.extend(["", f"## {strings['section_areas']}", ""])
     if snapshot.areas:
         for area in snapshot.areas:
             label = _md_escape(area.name)
@@ -132,15 +133,17 @@ def render_overview_auto_block(
             link = (
                 f"[{label}](page:{page_id})" if page_id is not None else f"**{label}**"
             )
-            lines.append(f"- {link} – {len(area.devices)} Geräte")
+            lines.append(
+                f"- {link} – {len(area.devices)} {strings['stat_devices']}",
+            )
     else:
-        lines.append("_Keine Areas konfiguriert._")
+        lines.append(strings["empty_areas"])
 
     if snapshot.unassigned_devices:
         lines.extend(
             [
                 "",
-                "## Geräte ohne Raum-Zuordnung",
+                f"## {strings['section_unassigned_devices']}",
                 "",
             ],
         )
@@ -153,89 +156,107 @@ def render_overview_auto_block(
     return "\n".join(lines)
 
 
-def render_area_auto_block(area: AreaSnapshot, now: datetime) -> str:
+def render_area_auto_block(
+    area: AreaSnapshot,
+    now: datetime,
+    strings: dict[str, str],
+) -> str:
     """Render the AUTO block of one area page."""
     lines: list[str] = [
-        _format_attribution(now),
+        _format_attribution(strings, now),
         "",
-        f"## Geräte in {_md_escape(area.name)}",
+        "## "
+        + strings["section_devices_in_area_template"].format(
+            name=_md_escape(area.name),
+        ),
         "",
     ]
     if area.devices:
         for device in area.devices:
             lines.extend(
-                [f"### {_md_escape(device.name)}", "", _device_facts_table(device)],
+                [
+                    f"### {_md_escape(device.name)}",
+                    "",
+                    _device_facts_table(device, strings),
+                ],
             )
             if device.entities:
                 lines.extend(
                     [
                         "",
-                        "**Entities**",
+                        f"**{strings['label_entities']}**",
                         "",
-                        *_entity_lines(device.entities),
+                        *_entity_lines(device.entities, strings),
                     ],
                 )
             lines.append("")
     else:
-        lines.append("_Keine Geräte in diesem Raum._")
+        lines.append(strings["empty_devices_in_room"])
 
     if area.orphan_entities:
         lines.extend(
             [
                 "",
-                "## Entities ohne Geräte-Zuordnung",
+                f"## {strings['section_orphan_entities']}",
                 "",
-                *_entity_lines(area.orphan_entities),
+                *_entity_lines(area.orphan_entities, strings),
             ],
         )
     return "\n".join(lines).rstrip() + "\n"
 
 
-def render_device_auto_block(device: DeviceSnapshot, now: datetime) -> str:
+def render_device_auto_block(
+    device: DeviceSnapshot,
+    now: datetime,
+    strings: dict[str, str],
+) -> str:
     """Render the AUTO block of one device page."""
     lines: list[str] = [
-        _format_attribution(now),
+        _format_attribution(strings, now),
         "",
-        "## Stammdaten",
+        f"## {strings['section_master_data']}",
         "",
-        _device_facts_table(device),
+        _device_facts_table(device, strings),
         "",
-        "## Entities",
+        f"## {strings['section_entities']}",
         "",
     ]
     if device.entities:
-        lines.extend(_entity_lines(device.entities))
+        lines.extend(_entity_lines(device.entities, strings))
     else:
-        lines.append("_Keine Entities zu diesem Gerät._")
+        lines.append(strings["empty_entities_in_device"])
     return "\n".join(lines).rstrip() + "\n"
 
 
 def render_addons_auto_block(
     addons: list[AddonSnapshot],
     now: datetime,
+    strings: dict[str, str],
 ) -> str:
     """Render the AUTO block listing every Supervisor add-on."""
     lines: list[str] = [
-        _format_attribution(now),
+        _format_attribution(strings, now),
         "",
-        f"## Add-ons ({len(addons)})",
+        "## " + strings["section_addons_count_template"].format(count=len(addons)),
         "",
     ]
     if not addons:
-        lines.append(
-            "_Kein Supervisor verfügbar oder keine Add-ons installiert._",
-        )
+        lines.append(strings["empty_addons"])
         return "\n".join(lines).rstrip() + "\n"
 
     lines.extend(
         [
-            "| Add-on | Slug | Version | Status | Update |",
+            f"| {strings['addon_col_name']} | {strings['addon_col_slug']} "
+            f"| {strings['addon_col_version']} | {strings['addon_col_state']} "
+            f"| {strings['addon_col_update']} |",
             "| --- | --- | --- | --- | --- |",
         ],
     )
+    yes = strings["addon_update_yes"]
+    no = strings["addon_update_no"]
     lines.extend(
         f"| {_md_escape(a.name)} | `{a.slug}` | {a.version or '—'} "
-        f"| {a.state or '—'} | {'Ja' if a.update_available else 'nein'} |"
+        f"| {a.state or '—'} | {yes if a.update_available else no} |"
         for a in addons
     )
     return "\n".join(lines).rstrip() + "\n"
@@ -244,56 +265,62 @@ def render_addons_auto_block(
 def render_automations_auto_block(
     automations: list[AutomationSnapshot],
     now: datetime,
+    strings: dict[str, str],
 ) -> str:
     """Render the AUTO block listing every HA automation."""
     lines: list[str] = [
-        _format_attribution(now),
+        _format_attribution(strings, now),
         "",
-        f"## Automatisierungen ({len(automations)})",
+        "## "
+        + strings["section_automations_count_template"].format(
+            count=len(automations),
+        ),
         "",
     ]
     if not automations:
-        lines.append("_Keine Automatisierungen vorhanden._")
+        lines.append(strings["empty_automations"])
         return "\n".join(lines).rstrip() + "\n"
 
     for auto in automations:
-        lines.extend(_automation_block(auto))
+        lines.extend(_automation_block(auto, strings))
     return "\n".join(lines).rstrip() + "\n"
 
 
 def render_scripts_auto_block(
     scripts: list[ScriptSnapshot],
     now: datetime,
+    strings: dict[str, str],
 ) -> str:
     """Render the AUTO block listing every HA script."""
     lines: list[str] = [
-        _format_attribution(now),
+        _format_attribution(strings, now),
         "",
-        f"## Skripte ({len(scripts)})",
+        "## " + strings["section_scripts_count_template"].format(count=len(scripts)),
         "",
     ]
     if not scripts:
-        lines.append("_Keine Skripte vorhanden._")
+        lines.append(strings["empty_scripts"])
         return "\n".join(lines).rstrip() + "\n"
 
     for script in scripts:
-        lines.extend(_script_block(script))
+        lines.extend(_script_block(script, strings))
     return "\n".join(lines).rstrip() + "\n"
 
 
 def render_scenes_auto_block(
     scenes: list[SceneSnapshot],
     now: datetime,
+    strings: dict[str, str],
 ) -> str:
     """Render the AUTO block listing every HA scene."""
     lines: list[str] = [
-        _format_attribution(now),
+        _format_attribution(strings, now),
         "",
-        f"## Szenen ({len(scenes)})",
+        "## " + strings["section_scenes_count_template"].format(count=len(scenes)),
         "",
     ]
     if not scenes:
-        lines.append("_Keine Szenen vorhanden._")
+        lines.append(strings["empty_scenes"])
         return "\n".join(lines).rstrip() + "\n"
 
     lines.extend(f"- **{_md_escape(s.name)}** – `{s.entity_id}`" for s in scenes)
@@ -303,24 +330,31 @@ def render_scenes_auto_block(
 def render_integrations_auto_block(
     integrations: list[IntegrationSnapshot],
     now: datetime,
+    strings: dict[str, str],
 ) -> str:
     """Render the AUTO block listing every installed integration / config entry."""
     lines: list[str] = [
-        _format_attribution(now),
+        _format_attribution(strings, now),
         "",
-        f"## Integrationen ({len(integrations)})",
+        "## "
+        + strings["section_integrations_count_template"].format(
+            count=len(integrations),
+        ),
         "",
     ]
     if not integrations:
-        lines.append("_Keine Integrationen geladen._")
+        lines.append(strings["empty_integrations"])
         return "\n".join(lines).rstrip() + "\n"
 
-    lines.extend(
-        [
-            "| Integration | Titel | Status | Quelle | Geräte | Entities |",
-            "| --- | --- | --- | --- | ---: | ---: |",
-        ],
+    header = (
+        f"| {strings['integration_col_name']} "
+        f"| {strings['integration_col_title']} "
+        f"| {strings['integration_col_state']} "
+        f"| {strings['integration_col_source']} "
+        f"| {strings['integration_col_devices']} "
+        f"| {strings['integration_col_entities']} |"
     )
+    lines.extend([header, "| --- | --- | --- | --- | ---: | ---: |"])
     lines.extend(
         f"| `{i.domain}` | {_md_escape(i.title)} | {i.state} | {i.source} "
         f"| {i.device_count} | {i.entity_count} |"
@@ -329,61 +363,74 @@ def render_integrations_auto_block(
     return "\n".join(lines).rstrip() + "\n"
 
 
-def _device_facts_table(device: DeviceSnapshot) -> str:
+def _device_facts_table(device: DeviceSnapshot, strings: dict[str, str]) -> str:
     rows = [
-        ("Hersteller", _md_escape(device.manufacturer or "—")),
-        ("Modell", _md_escape(device.model or "—")),
-        ("Firmware", _md_escape(device.sw_version or "—")),
-        ("Hardware", _md_escape(device.hw_version or "—")),
+        (strings["field_manufacturer"], _md_escape(device.manufacturer or "—")),
+        (strings["field_model"], _md_escape(device.model or "—")),
+        (strings["field_firmware"], _md_escape(device.sw_version or "—")),
+        (strings["field_hardware"], _md_escape(device.hw_version or "—")),
         (
-            "Integrationen",
+            strings["field_integrations"],
             _md_escape(", ".join(device.config_entries) or "—"),
         ),
-        ("Device-ID", device.device_id),
+        (strings["field_device_id"], device.device_id),
     ]
-    out = ["| Feld | Wert |", "| --- | --- |"]
+    header = f"| {strings['table_field_header']} | {strings['table_value_header']} |"
+    out = [header, "| --- | --- |"]
     out.extend(f"| {key} | {value} |" for key, value in rows)
     return "\n".join(out)
 
 
-def _entity_lines(entities: list[EntitySnapshot]) -> list[str]:
+def _entity_lines(
+    entities: list[EntitySnapshot],
+    strings: dict[str, str],
+) -> list[str]:
+    state_label = strings["entity_state_label"]
+    topic_label = strings["entity_topic_label"]
+    disabled = strings["entity_disabled_marker"]
     return [
         f"- `{e.entity_id}` – {_md_escape(e.name)}"
-        + (f" (State: `{e.state}`)" if e.state is not None else "")
-        + (f" (Topic: `{e.mqtt_topic}`)" if e.mqtt_topic else "")
-        + (" _[disabled]_" if e.disabled else "")
+        + (f" ({state_label}: `{e.state}`)" if e.state is not None else "")
+        + (f" ({topic_label}: `{e.mqtt_topic}`)" if e.mqtt_topic else "")
+        + (f" {disabled}" if e.disabled else "")
         for e in entities
     ]
 
 
-def _automation_block(auto: AutomationSnapshot) -> list[str]:
+def _automation_block(
+    auto: AutomationSnapshot,
+    strings: dict[str, str],
+) -> list[str]:
     block = [
         f"### {_md_escape(auto.name)}",
         "",
-        f"- Entity: `{auto.entity_id}`",
+        f"- {strings['field_entity']}: `{auto.entity_id}`",
     ]
     if auto.state is not None:
-        block.append(f"- Status: `{auto.state}`")
+        block.append(f"- {strings['field_status']}: `{auto.state}`")
     if auto.mode:
-        block.append(f"- Modus: `{auto.mode}`")
+        block.append(f"- {strings['field_mode']}: `{auto.mode}`")
     if auto.last_triggered:
-        block.append(f"- Letzter Trigger: {auto.last_triggered}")
+        block.append(f"- {strings['field_last_triggered']}: {auto.last_triggered}")
     if auto.description:
         block.extend(["", f"> {auto.description}"])
     block.append("")
     return block
 
 
-def _script_block(script: ScriptSnapshot) -> list[str]:
+def _script_block(
+    script: ScriptSnapshot,
+    strings: dict[str, str],
+) -> list[str]:
     block = [
         f"### {_md_escape(script.name)}",
         "",
-        f"- Entity: `{script.entity_id}`",
+        f"- {strings['field_entity']}: `{script.entity_id}`",
     ]
     if script.state is not None:
-        block.append(f"- Status: `{script.state}`")
+        block.append(f"- {strings['field_status']}: `{script.state}`")
     if script.last_triggered:
-        block.append(f"- Letzter Trigger: {script.last_triggered}")
+        block.append(f"- {strings['field_last_triggered']}: {script.last_triggered}")
     if script.description:
         block.extend(["", f"> {script.description}"])
     block.append("")

--- a/custom_components/bookstack_sync/strings.json
+++ b/custom_components/bookstack_sync/strings.json
@@ -46,7 +46,8 @@
         "data": {
           "book_id": "Ziel-Book",
           "sync_interval": "Sync-Intervall",
-          "excluded_areas": "Ausgeschlossene Räume (werden nicht synchronisiert)"
+          "excluded_areas": "Ausgeschlossene Räume (werden nicht synchronisiert)",
+          "output_language": "Sprache der BookStack-Pages"
         }
       }
     }
@@ -57,6 +58,13 @@
         "hourly": "Stündlich",
         "daily": "Täglich",
         "manual": "Nur manuell (Service-Aufruf)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Wie Home Assistant (automatisch)",
+        "de": "Deutsch",
+        "en": "Englisch"
       }
     }
   },

--- a/custom_components/bookstack_sync/sync.py
+++ b/custom_components/bookstack_sync/sync.py
@@ -2,12 +2,16 @@
 Sync orchestrator: snapshot HA -> render -> merge -> push to BookStack.
 
 Flow per run:
-1. ``ensure_chapters`` makes sure ``Räume`` + ``Geräte`` chapters exist.
+1. ``ensure_chapters`` makes sure ``Räume`` + ``Geräte`` chapters exist
+   (titles + descriptions come from the active output language).
 2. Pass 1 syncs all area / device / bundle pages and collects their page IDs.
-3. Pass 2 renders the Übersicht with markdown links to the IDs from pass 1
+3. Pass 2 renders the overview with markdown links to the IDs from pass 1
    and writes it.
 4. Pages whose HA object has vanished get a one-time tombstone block.
 5. Mapping store is persisted and a persistent notification is posted.
+
+The active output language is passed in via ``strings`` — see
+``_strings.get_strings``. Default in coordinator is ``hass.config.language``.
 """
 
 from __future__ import annotations
@@ -23,12 +27,8 @@ from homeassistant.components.persistent_notification import (
 
 from .api import BookStackApiAuthError, BookStackApiError
 from .const import (
-    CHAPTER_DESC_AREAS,
-    CHAPTER_DESC_DEVICES,
     CHAPTER_KEY_AREAS,
     CHAPTER_KEY_DEVICES,
-    CHAPTER_TITLE_AREAS,
-    CHAPTER_TITLE_DEVICES,
     LOGGER,
     PAGE_KIND_ADDONS,
     PAGE_KIND_AREA,
@@ -116,58 +116,74 @@ class _PlannedPage:
     chapter_key: str | None = None  # None = page lives at book level
 
 
-def _device_page(device: DeviceSnapshot, now: datetime) -> _PlannedPage:
+def _device_page(
+    device: DeviceSnapshot,
+    now: datetime,
+    strings: dict[str, str],
+) -> _PlannedPage:
     return _PlannedPage(
         key=f"{PAGE_KIND_DEVICE}:{device.device_id}",
-        title=f"Gerät: {device.name}",
-        auto_body=render_device_auto_block(device, now),
+        title=strings["title_device_template"].format(name=device.name),
+        auto_body=render_device_auto_block(device, now, strings),
         chapter_key=CHAPTER_KEY_DEVICES,
     )
 
 
-def _plan_pages(snapshot: HASnapshot, now: datetime) -> list[_PlannedPage]:
+def _plan_pages(
+    snapshot: HASnapshot,
+    now: datetime,
+    strings: dict[str, str],
+) -> list[_PlannedPage]:
     """Plan all pages EXCEPT the overview (rendered in a second pass)."""
     planned: list[_PlannedPage] = [
         _PlannedPage(
             key=f"{PAGE_KIND_INTEGRATIONS}:_",
-            title="Home Assistant – Integrationen",
-            auto_body=render_integrations_auto_block(snapshot.integrations, now),
+            title=strings["title_integrations"],
+            auto_body=render_integrations_auto_block(
+                snapshot.integrations,
+                now,
+                strings,
+            ),
         ),
         _PlannedPage(
             key=f"{PAGE_KIND_AUTOMATIONS}:_",
-            title="Home Assistant – Automatisierungen",
-            auto_body=render_automations_auto_block(snapshot.automations, now),
+            title=strings["title_automations"],
+            auto_body=render_automations_auto_block(
+                snapshot.automations,
+                now,
+                strings,
+            ),
         ),
         _PlannedPage(
             key=f"{PAGE_KIND_SCRIPTS}:_",
-            title="Home Assistant – Skripte",
-            auto_body=render_scripts_auto_block(snapshot.scripts, now),
+            title=strings["title_scripts"],
+            auto_body=render_scripts_auto_block(snapshot.scripts, now, strings),
         ),
         _PlannedPage(
             key=f"{PAGE_KIND_SCENES}:_",
-            title="Home Assistant – Szenen",
-            auto_body=render_scenes_auto_block(snapshot.scenes, now),
+            title=strings["title_scenes"],
+            auto_body=render_scenes_auto_block(snapshot.scenes, now, strings),
         ),
     ]
     if snapshot.addons:
         planned.append(
             _PlannedPage(
                 key=f"{PAGE_KIND_ADDONS}:_",
-                title="Home Assistant – Add-ons",
-                auto_body=render_addons_auto_block(snapshot.addons, now),
+                title=strings["title_addons"],
+                auto_body=render_addons_auto_block(snapshot.addons, now, strings),
             ),
         )
     for area in snapshot.areas:
         planned.append(
             _PlannedPage(
                 key=f"{PAGE_KIND_AREA}:{area.area_id}",
-                title=f"Raum: {area.name}",
-                auto_body=render_area_auto_block(area, now),
+                title=strings["title_area_template"].format(name=area.name),
+                auto_body=render_area_auto_block(area, now, strings),
                 chapter_key=CHAPTER_KEY_AREAS,
             ),
         )
-        planned.extend(_device_page(d, now) for d in area.devices)
-    planned.extend(_device_page(d, now) for d in snapshot.unassigned_devices)
+        planned.extend(_device_page(d, now, strings) for d in area.devices)
+    planned.extend(_device_page(d, now, strings) for d in snapshot.unassigned_devices)
     return planned
 
 
@@ -175,11 +191,20 @@ async def _ensure_chapters(
     client: BookStackApiClient,
     store: BookStackSyncStore,
     book_id: int,
+    strings: dict[str, str],
 ) -> dict[str, int]:
     """Make sure the area + device chapters exist; return their IDs."""
     desired = (
-        (CHAPTER_KEY_AREAS, CHAPTER_TITLE_AREAS, CHAPTER_DESC_AREAS),
-        (CHAPTER_KEY_DEVICES, CHAPTER_TITLE_DEVICES, CHAPTER_DESC_DEVICES),
+        (
+            CHAPTER_KEY_AREAS,
+            strings["chapter_areas_title"],
+            strings["chapter_areas_description"],
+        ),
+        (
+            CHAPTER_KEY_DEVICES,
+            strings["chapter_devices_title"],
+            strings["chapter_devices_description"],
+        ),
     )
     existing_chapters = await client.list_chapters(book_id)
     existing_ids = {int(ch["id"]) for ch in existing_chapters}
@@ -207,6 +232,7 @@ async def run_sync(  # noqa: PLR0913 - cohesive entry point
     client: BookStackApiClient,
     store: BookStackSyncStore,
     book_id: int,
+    strings: dict[str, str],
     *,
     dry_run: bool = False,
     excluded_area_ids: Iterable[str] = (),
@@ -218,10 +244,12 @@ async def run_sync(  # noqa: PLR0913 - cohesive entry point
     # Registries are pure in-memory dict lookups and must run on the event
     # loop thread - never wrap them in async_add_executor_job.
     snapshot = extract_snapshot(hass, excluded_area_ids=excluded_area_ids)
-    planned = _plan_pages(snapshot, now)
+    planned = _plan_pages(snapshot, now, strings)
 
     await store.async_load()
-    chapters = {} if dry_run else await _ensure_chapters(client, store, book_id)
+    chapters = (
+        {} if dry_run else await _ensure_chapters(client, store, book_id, strings)
+    )
 
     # Pass 1: sync all non-overview pages, collect their IDs for the overview.
     page_ids: dict[str, int] = {}
@@ -255,8 +283,13 @@ async def run_sync(  # noqa: PLR0913 - cohesive entry point
     # Pass 2: render overview with page links + sync it.
     overview = _PlannedPage(
         key=f"{PAGE_KIND_OVERVIEW}:_",
-        title="Home Assistant – Übersicht",
-        auto_body=render_overview_auto_block(snapshot, now, page_links=page_ids),
+        title=strings["title_overview"],
+        auto_body=render_overview_auto_block(
+            snapshot,
+            now,
+            strings,
+            page_links=page_ids,
+        ),
     )
     try:
         await _sync_one(
@@ -277,7 +310,15 @@ async def run_sync(  # noqa: PLR0913 - cohesive entry point
         report.errors.append(f"{overview.key}: {err}")
 
     all_planned = [overview, *planned]
-    await _tombstone_orphans(client, store, all_planned, report, now, dry_run=dry_run)
+    await _tombstone_orphans(
+        client,
+        store,
+        all_planned,
+        report,
+        now,
+        strings,
+        dry_run=dry_run,
+    )
 
     if not dry_run:
         await store.async_save()
@@ -294,23 +335,27 @@ async def run_sync(  # noqa: PLR0913 - cohesive entry point
         " (dry-run)" if dry_run else "",
     )
     if not dry_run:
-        _post_sync_notification(hass, report)
+        _post_sync_notification(hass, report, strings)
     return report
 
 
-def _post_sync_notification(hass: HomeAssistant, report: SyncReport) -> None:
-    bullet = (
-        f"- {len(report.created)} angelegt\n"
-        f"- {len(report.updated)} aktualisiert\n"
-        f"- {len(report.unchanged)} unverändert\n"
-        f"- {len(report.tombstoned)} verwaist (Tombstone)\n"
-        f"- {len(report.skipped_conflict)} mit Konflikt übersprungen\n"
-        f"- {len(report.errors)} Fehler"
+def _post_sync_notification(
+    hass: HomeAssistant,
+    report: SyncReport,
+    strings: dict[str, str],
+) -> None:
+    body = strings["notification_body_template"].format(
+        created=len(report.created),
+        updated=len(report.updated),
+        unchanged=len(report.unchanged),
+        tombstoned=len(report.tombstoned),
+        skipped=len(report.skipped_conflict),
+        errors=len(report.errors),
     )
     async_create_notification(
         hass,
-        f"BookStack-Sync abgeschlossen:\n\n{bullet}",
-        title="BookStack Sync",
+        body,
+        title=strings["notification_title"],
         notification_id="bookstack_sync_last_run",
     )
 
@@ -369,8 +414,7 @@ async def _sync_one(  # noqa: PLR0913 - cohesive sync step, splitting hurts clar
         return page_id
 
     existing = await client.get_page(mapping.page_id)
-    existing_chapter_id = existing.get("chapter_id") or 0
-    needs_move = chapter_id is not None and int(existing_chapter_id) != chapter_id
+    needs_move = _needs_move(existing, chapter_id, page.key)
 
     existing_markdown = existing.get("markdown") or existing.get("raw_html") or ""
     existing_auto = extract_auto_block(existing_markdown)
@@ -421,12 +465,44 @@ async def _sync_one(  # noqa: PLR0913 - cohesive sync step, splitting hurts clar
     return mapping.page_id
 
 
+def _needs_move(
+    existing: dict,
+    expected_chapter_id: int | None,
+    page_key: str,
+) -> bool:
+    """
+    Return whether the existing page needs to be moved into ``expected_chapter_id``.
+
+    Defensively coerces BookStack's response: ``chapter_id`` can come back as
+    int, str, None or missing. Anything that doesn't parse to the expected
+    target is treated as "needs move" rather than crashing — this is what
+    finally clears the V0.1.x findlings stuck at book level on long-running
+    setups.
+    """
+    if expected_chapter_id is None:
+        return False
+    raw = existing.get("chapter_id")
+    try:
+        actual = int(raw) if raw is not None else 0
+    except TypeError, ValueError:
+        LOGGER.warning(
+            "BookStack returned non-numeric chapter_id %r for %s "
+            "(page id=%s); treating as needs-move",
+            raw,
+            page_key,
+            existing.get("id"),
+        )
+        return True
+    return actual != expected_chapter_id
+
+
 async def _tombstone_orphans(  # noqa: PLR0913 - cohesive sync step
     client: BookStackApiClient,
     store: BookStackSyncStore,
     planned: list[_PlannedPage],
     report: SyncReport,
     now: datetime,
+    strings: dict[str, str],
     *,
     dry_run: bool,
 ) -> None:
@@ -446,6 +522,7 @@ async def _tombstone_orphans(  # noqa: PLR0913 - cohesive sync step
                 mapping,
                 report,
                 now,
+                strings,
                 dry_run=dry_run,
             )
         except BookStackApiAuthError:
@@ -467,10 +544,11 @@ async def _tombstone_one(  # noqa: PLR0913 - cohesive sync step
     mapping: PageMapping,
     report: SyncReport,
     now: datetime,
+    strings: dict[str, str],
     *,
     dry_run: bool,
 ) -> None:
-    auto_body = render_tombstone_auto_block(now)
+    auto_body = render_tombstone_auto_block(strings, now)
     new_hash = hash_auto_block(auto_body)
 
     existing = await client.get_page(mapping.page_id)

--- a/custom_components/bookstack_sync/translations/de.json
+++ b/custom_components/bookstack_sync/translations/de.json
@@ -46,7 +46,8 @@
         "data": {
           "book_id": "Ziel-Book",
           "sync_interval": "Sync-Intervall",
-          "excluded_areas": "Ausgeschlossene Räume (werden nicht synchronisiert)"
+          "excluded_areas": "Ausgeschlossene Räume (werden nicht synchronisiert)",
+          "output_language": "Sprache der BookStack-Pages"
         }
       }
     }
@@ -57,6 +58,13 @@
         "hourly": "Stündlich",
         "daily": "Täglich",
         "manual": "Nur manuell (Service-Aufruf)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Wie Home Assistant (automatisch)",
+        "de": "Deutsch",
+        "en": "Englisch"
       }
     }
   },

--- a/custom_components/bookstack_sync/translations/en.json
+++ b/custom_components/bookstack_sync/translations/en.json
@@ -46,7 +46,8 @@
         "data": {
           "book_id": "Target book",
           "sync_interval": "Sync interval",
-          "excluded_areas": "Excluded areas (will not be synced)"
+          "excluded_areas": "Excluded areas (will not be synced)",
+          "output_language": "Language of the BookStack pages"
         }
       }
     }
@@ -57,6 +58,13 @@
         "hourly": "Hourly",
         "daily": "Daily",
         "manual": "Manual only (service call)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Follow Home Assistant (auto)",
+        "de": "German",
+        "en": "English"
       }
     }
   },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.bookstack_sync._strings import get_strings
 from custom_components.bookstack_sync.const import (
     CONF_BASE_URL,
     CONF_BOOK_ID,
@@ -27,6 +28,18 @@ if TYPE_CHECKING:
 def fixed_now() -> datetime:
     """A stable timestamp so renderer output is byte-identical across runs."""
     return datetime(2026, 4, 28, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def strings_de() -> dict[str, str]:
+    """German output strings used across renderer tests."""
+    return get_strings("de")
+
+
+@pytest.fixture
+def strings_en() -> dict[str, str]:
+    """English output strings used across renderer tests."""
+    return get_strings("en")
 
 
 # Allow this custom integration to be loaded by pytest-homeassistant-custom-component.

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -2,6 +2,8 @@
 
 The renderer's whole point is byte-identical output for unchanged input,
 so the renderer-determinism property is the first thing we lock down.
+After v0.4.0 every renderer takes a ``strings`` dict so we also assert
+that output language follows that dict (DE vs EN).
 """
 
 from __future__ import annotations
@@ -9,9 +11,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
-
-if TYPE_CHECKING:
-    from datetime import datetime
 
 from custom_components.bookstack_sync.extractor import (
     AddonSnapshot,
@@ -36,6 +35,10 @@ from custom_components.bookstack_sync.renderer import (
     render_scripts_auto_block,
     render_tombstone_auto_block,
 )
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 # ---------------------------------------------------------------------------
 # helpers
@@ -110,58 +113,155 @@ class TestMdEscape:
 class TestDeterminism:
     """Same input must produce byte-identical output across calls."""
 
-    def test_overview_is_deterministic(self, fixed_now: datetime) -> None:
+    def test_overview_is_deterministic(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
         snap = _empty_snapshot()
-        first = render_overview_auto_block(snap, fixed_now)
-        second = render_overview_auto_block(snap, fixed_now)
+        first = render_overview_auto_block(snap, fixed_now, strings_de)
+        second = render_overview_auto_block(snap, fixed_now, strings_de)
         assert first == second
 
-    def test_area_is_deterministic(self, fixed_now: datetime) -> None:
+    def test_area_is_deterministic(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
         area = AreaSnapshot(
             area_id="living",
             name="Living Room",
             devices=[_device("d1"), _device("d2")],
             orphan_entities=[],
         )
-        first = render_area_auto_block(area, fixed_now)
-        second = render_area_auto_block(area, fixed_now)
+        first = render_area_auto_block(area, fixed_now, strings_de)
+        second = render_area_auto_block(area, fixed_now, strings_de)
         assert first == second
 
-    def test_device_is_deterministic(self, fixed_now: datetime) -> None:
+    def test_device_is_deterministic(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
         device = _device(name="Tasmota Plug")
         device.entities.extend([_entity("switch.a"), _entity("sensor.b")])
-        first = render_device_auto_block(device, fixed_now)
-        second = render_device_auto_block(device, fixed_now)
+        first = render_device_auto_block(device, fixed_now, strings_de)
+        second = render_device_auto_block(device, fixed_now, strings_de)
         assert first == second
+
+
+class TestI18n:
+    """The strings dict drives the visible language; same input differs by lang."""
+
+    def test_overview_is_german(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
+        out = render_overview_auto_block(_empty_snapshot(), fixed_now, strings_de)
+        assert "## Statistik" in out
+        assert "Räume" in out
+        assert "Bereiche" in out
+        assert "Statistics" not in out
+
+    def test_overview_is_english(
+        self,
+        fixed_now: datetime,
+        strings_en: dict[str, str],
+    ) -> None:
+        out = render_overview_auto_block(_empty_snapshot(), fixed_now, strings_en)
+        assert "## Statistics" in out
+        assert "Areas" in out
+        assert "Sections" in out
+        assert "Statistik" not in out
+
+    def test_device_table_translates_field_labels(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+        strings_en: dict[str, str],
+    ) -> None:
+        device = _device()
+        de_out = render_device_auto_block(device, fixed_now, strings_de)
+        en_out = render_device_auto_block(device, fixed_now, strings_en)
+        assert "Hersteller" in de_out
+        assert "Manufacturer" in en_out
+        assert "Manufacturer" not in de_out
+        assert "Hersteller" not in en_out
+
+    def test_addon_table_translates_yes_no(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+        strings_en: dict[str, str],
+    ) -> None:
+        addons = [
+            AddonSnapshot(
+                slug="x",
+                name="X",
+                version="1",
+                state="started",
+                update_available=True,
+            ),
+        ]
+        de_out = render_addons_auto_block(addons, fixed_now, strings_de)
+        en_out = render_addons_auto_block(addons, fixed_now, strings_en)
+        assert "| Ja |" in de_out
+        assert "| Yes |" in en_out
+
+    def test_tombstone_speaks_chosen_language(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+        strings_en: dict[str, str],
+    ) -> None:
+        de = render_tombstone_auto_block(strings_de, fixed_now)
+        en = render_tombstone_auto_block(strings_en, fixed_now)
+        assert "verwaist" in de
+        assert "orphaned" in en
 
 
 class TestOverviewLinks:
     """Overview must use BookStack page-link syntax when ids are provided."""
 
-    def test_area_link_rendered(self, fixed_now: datetime) -> None:
+    def test_area_link_rendered(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
         area = AreaSnapshot(area_id="living", name="Living Room")
         snap = _empty_snapshot()
         snap.areas.append(area)
         out = render_overview_auto_block(
             snap,
             fixed_now,
+            strings_de,
             page_links={"area:living": 42},
         )
         assert "[Living Room](page:42)" in out
 
-    def test_area_falls_back_to_bold_when_no_link(self, fixed_now: datetime) -> None:
+    def test_area_falls_back_to_bold_when_no_link(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
         area = AreaSnapshot(area_id="living", name="Living Room")
         snap = _empty_snapshot()
         snap.areas.append(area)
-        out = render_overview_auto_block(snap, fixed_now)
+        out = render_overview_auto_block(snap, fixed_now, strings_de)
         assert "**Living Room**" in out
         assert "page:" not in out
 
-    def test_bundle_links_rendered(self, fixed_now: datetime) -> None:
+    def test_bundle_links_rendered(
+        self,
+        fixed_now: datetime,
+        strings_en: dict[str, str],
+    ) -> None:
         snap = _empty_snapshot()
         out = render_overview_auto_block(
             snap,
             fixed_now,
+            strings_en,
             page_links={
                 "integrations:_": 1,
                 "automations:_": 2,
@@ -170,20 +270,24 @@ class TestOverviewLinks:
                 "addons:_": 5,
             },
         )
-        assert "[Integrationen](page:1)" in out
-        assert "[Automatisierungen](page:2)" in out
-        assert "[Skripte](page:3)" in out
-        assert "[Szenen](page:4)" in out
+        assert "[Integrations](page:1)" in out
+        assert "[Automations](page:2)" in out
+        assert "[Scripts](page:3)" in out
+        assert "[Scenes](page:4)" in out
         assert "[Add-ons](page:5)" in out
 
-    def test_special_chars_in_area_name_escaped(self, fixed_now: datetime) -> None:
-        # Names like "Wohn|zimmer <stage>" must not break the markdown table.
+    def test_special_chars_in_area_name_escaped(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
         area = AreaSnapshot(area_id="living", name="Wohn|zimmer <stage>")
         snap = _empty_snapshot()
         snap.areas.append(area)
         out = render_overview_auto_block(
             snap,
             fixed_now,
+            strings_de,
             page_links={"area:living": 99},
         )
         assert r"Wohn\|zimmer &lt;stage&gt;" in out
@@ -195,6 +299,7 @@ class TestBundlePages:
     def test_automations_with_description_rendered_as_quote(
         self,
         fixed_now: datetime,
+        strings_de: dict[str, str],
     ) -> None:
         autos = [
             AutomationSnapshot(
@@ -206,16 +311,24 @@ class TestBundlePages:
                 last_triggered="2026-04-28T06:00:00+00:00",
             ),
         ]
-        out = render_automations_auto_block(autos, fixed_now)
+        out = render_automations_auto_block(autos, fixed_now, strings_de)
         assert "### Foo" in out
         assert "`automation.foo`" in out
         assert "> Wakes me up" in out
 
-    def test_empty_automations_emits_placeholder(self, fixed_now: datetime) -> None:
-        out = render_automations_auto_block([], fixed_now)
+    def test_empty_automations_emits_placeholder(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
+        out = render_automations_auto_block([], fixed_now, strings_de)
         assert "Keine Automatisierungen" in out
 
-    def test_scripts_use_md_escape_for_name(self, fixed_now: datetime) -> None:
+    def test_scripts_use_md_escape_for_name(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
         scripts = [
             ScriptSnapshot(
                 entity_id="script.foo",
@@ -225,16 +338,24 @@ class TestBundlePages:
                 last_triggered=None,
             ),
         ]
-        out = render_scripts_auto_block(scripts, fixed_now)
+        out = render_scripts_auto_block(scripts, fixed_now, strings_de)
         assert r"### Foo\|Bar" in out
 
-    def test_scenes_table_format(self, fixed_now: datetime) -> None:
+    def test_scenes_table_format(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
         scenes = [SceneSnapshot(entity_id="scene.bedtime", name="Bedtime")]
-        out = render_scenes_auto_block(scenes, fixed_now)
+        out = render_scenes_auto_block(scenes, fixed_now, strings_de)
         assert "**Bedtime**" in out
         assert "`scene.bedtime`" in out
 
-    def test_integrations_table_columns_present(self, fixed_now: datetime) -> None:
+    def test_integrations_table_columns_present(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
         integ = [
             IntegrationSnapshot(
                 entry_id="abc",
@@ -246,14 +367,18 @@ class TestBundlePages:
                 entity_count=42,
             ),
         ]
-        out = render_integrations_auto_block(integ, fixed_now)
+        out = render_integrations_auto_block(integ, fixed_now, strings_de)
         assert "`mqtt`" in out
         assert "MQTT Broker" in out
         assert "loaded" in out
         assert "12" in out
         assert "42" in out
 
-    def test_addons_table(self, fixed_now: datetime) -> None:
+    def test_addons_table(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
         addons = [
             AddonSnapshot(
                 slug="core_zwave",
@@ -263,45 +388,65 @@ class TestBundlePages:
                 update_available=True,
             ),
         ]
-        out = render_addons_auto_block(addons, fixed_now)
+        out = render_addons_auto_block(addons, fixed_now, strings_de)
         assert "`core_zwave`" in out
         assert "Z-Wave" in out
         assert "1.2.3" in out
         assert "started" in out
         assert "Ja" in out
 
-    def test_no_addons_emits_supervisor_placeholder(self, fixed_now: datetime) -> None:
-        out = render_addons_auto_block([], fixed_now)
+    def test_no_addons_emits_supervisor_placeholder(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
+        out = render_addons_auto_block([], fixed_now, strings_de)
         assert "Kein Supervisor" in out
 
 
 class TestTombstone:
     """Tombstone-block has the obvious warning + date format."""
 
-    def test_tombstone_contains_date(self, fixed_now: datetime) -> None:
-        out = render_tombstone_auto_block(fixed_now)
+    def test_tombstone_contains_date(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
+        out = render_tombstone_auto_block(strings_de, fixed_now)
         assert "2026-04-28" in out
 
-    def test_tombstone_has_warning_header(self, fixed_now: datetime) -> None:
-        out = render_tombstone_auto_block(fixed_now)
+    def test_tombstone_has_warning_header(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
+        out = render_tombstone_auto_block(strings_de, fixed_now)
         assert "verwaist" in out
 
 
 class TestEntityLinesMqttTopic:
     """MQTT topic should be surfaced when present in the entity attributes."""
 
-    def test_mqtt_topic_rendered_when_present(self, fixed_now: datetime) -> None:
+    def test_mqtt_topic_rendered_when_present(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
         device = _device()
         entity = _entity()
         entity.mqtt_topic = "tasmota/plug3/STATE"
         device.entities.append(entity)
-        out = render_device_auto_block(device, fixed_now)
+        out = render_device_auto_block(device, fixed_now, strings_de)
         assert "(Topic: `tasmota/plug3/STATE`)" in out
 
-    def test_no_topic_means_no_topic_marker(self, fixed_now: datetime) -> None:
+    def test_no_topic_means_no_topic_marker(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
         device = _device()
         device.entities.append(_entity())
-        out = render_device_auto_block(device, fixed_now)
+        out = render_device_auto_block(device, fixed_now, strings_de)
         assert "Topic" not in out
 
 
@@ -316,15 +461,17 @@ class TestEntityLinesMqttTopic:
 def test_all_renderers_include_attribution(
     render_fn: object,
     fixed_now: datetime,
+    strings_de: dict[str, str],
 ) -> None:
     """Every page is timestamped + attributed - verifies _format_attribution path."""
     if render_fn is render_overview_auto_block:
-        out = render_overview_auto_block(_empty_snapshot(), fixed_now)
+        out = render_overview_auto_block(_empty_snapshot(), fixed_now, strings_de)
     elif render_fn is render_area_auto_block:
         out = render_area_auto_block(
             AreaSnapshot(area_id="x", name="X"),
             fixed_now,
+            strings_de,
         )
     else:
-        out = render_device_auto_block(_device(), fixed_now)
-    assert "Stand 2026-04-28 12:00 UTC" in out
+        out = render_device_auto_block(_device(), fixed_now, strings_de)
+    assert "2026-04-28 12:00 UTC" in out

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -15,11 +15,10 @@ from homeassistant.helpers import (
     area_registry as ar,
 )
 
+from custom_components.bookstack_sync._strings import get_strings
 from custom_components.bookstack_sync.const import (
     CHAPTER_KEY_AREAS,
     CHAPTER_KEY_DEVICES,
-    CHAPTER_TITLE_AREAS,
-    CHAPTER_TITLE_DEVICES,
 )
 from custom_components.bookstack_sync.store import BookStackSyncStore
 from custom_components.bookstack_sync.sync import run_sync
@@ -102,9 +101,16 @@ async def store(hass: HomeAssistant) -> BookStackSyncStore:
     return s
 
 
+@pytest.fixture
+def strings() -> dict[str, str]:
+    """Default to German strings for sync tests (tests our home-base output)."""
+    return get_strings("de")
+
+
 async def test_first_sync_creates_chapters_and_pages(
     hass: HomeAssistant,
     store: BookStackSyncStore,
+    strings: dict[str, str],
 ) -> None:
     state: dict[str, Any] = {}
     client = _fake_client_with_state(state)
@@ -113,11 +119,11 @@ async def test_first_sync_creates_chapters_and_pages(
     area_reg = ar.async_get(hass)
     area_reg.async_create("Living Room")
 
-    report = await run_sync(hass, client, store, book_id=1)
+    report = await run_sync(hass, client, store, 1, strings)
 
-    # Both chapters auto-created
-    assert CHAPTER_TITLE_AREAS in state["chapters"].values()
-    assert CHAPTER_TITLE_DEVICES in state["chapters"].values()
+    # Both chapters auto-created (titles come from the active language).
+    assert strings["chapter_areas_title"] in state["chapters"].values()
+    assert strings["chapter_devices_title"] in state["chapters"].values()
     assert store.get_chapter(CHAPTER_KEY_AREAS) is not None
     assert store.get_chapter(CHAPTER_KEY_DEVICES) is not None
 
@@ -129,6 +135,7 @@ async def test_first_sync_creates_chapters_and_pages(
 async def test_second_sync_with_unchanged_data_makes_no_changes(
     hass: HomeAssistant,
     store: BookStackSyncStore,
+    strings: dict[str, str],
 ) -> None:
     state: dict[str, Any] = {}
     client = _fake_client_with_state(state)
@@ -136,11 +143,11 @@ async def test_second_sync_with_unchanged_data_makes_no_changes(
     area_reg.async_create("Living Room")
 
     # First sync: creates everything
-    await run_sync(hass, client, store, book_id=1)
+    await run_sync(hass, client, store, 1, strings)
 
     # Second sync should be all-unchanged (this is the regression hot spot
     # we just fixed in v0.2.1: false-positive tampering after first write).
-    report2 = await run_sync(hass, client, store, book_id=1)
+    report2 = await run_sync(hass, client, store, 1, strings)
     assert report2.created == []
     assert report2.skipped_conflict == []  # NO false positives
     assert report2.errors == []
@@ -149,11 +156,12 @@ async def test_second_sync_with_unchanged_data_makes_no_changes(
 async def test_dry_run_does_not_call_writes(
     hass: HomeAssistant,
     store: BookStackSyncStore,
+    strings: dict[str, str],
 ) -> None:
     state: dict[str, Any] = {}
     client = _fake_client_with_state(state)
 
-    report = await run_sync(hass, client, store, book_id=1, dry_run=True)
+    report = await run_sync(hass, client, store, 1, strings, dry_run=True)
     assert report.dry_run is True
     client.create_page.assert_not_called()
     client.update_page.assert_not_called()
@@ -163,20 +171,38 @@ async def test_dry_run_does_not_call_writes(
 async def test_chapter_reused_when_already_present(
     hass: HomeAssistant,
     store: BookStackSyncStore,
+    strings: dict[str, str],
 ) -> None:
-    # Seed BookStack with an existing "Räume" chapter from a previous setup.
     state: dict[str, Any] = {
-        "chapters": {500: CHAPTER_TITLE_AREAS},
+        "chapters": {500: strings["chapter_areas_title"]},
         "next_id": 600,
     }
     client = _fake_client_with_state(state)
 
-    await run_sync(hass, client, store, book_id=1)
+    await run_sync(hass, client, store, 1, strings)
 
-    # We must NOT have created a duplicate "Räume" chapter — only
-    # "Geräte" was missing.
+    # We must NOT have created a duplicate area chapter - only the device
+    # chapter was missing.
     chapter_titles = list(state["chapters"].values())
-    assert chapter_titles.count(CHAPTER_TITLE_AREAS) == 1
-    assert chapter_titles.count(CHAPTER_TITLE_DEVICES) == 1
-    # Stored mapping points at the pre-existing chapter id (500), not a new one.
+    assert chapter_titles.count(strings["chapter_areas_title"]) == 1
+    assert chapter_titles.count(strings["chapter_devices_title"]) == 1
     assert store.get_chapter(CHAPTER_KEY_AREAS) == 500
+
+
+async def test_english_run_creates_english_titled_chapters(
+    hass: HomeAssistant,
+    store: BookStackSyncStore,
+) -> None:
+    """v0.4.0 regression: chapter titles follow the strings dict."""
+    state: dict[str, Any] = {}
+    client = _fake_client_with_state(state)
+    en = get_strings("en")
+
+    await run_sync(hass, client, store, 1, en)
+
+    chapter_titles = list(state["chapters"].values())
+    assert "Areas" in chapter_titles
+    assert "Devices" in chapter_titles
+    # And no German leftovers.
+    assert "Räume" not in chapter_titles
+    assert "Geräte" not in chapter_titles


### PR DESCRIPTION
Three threads:

1. **Output i18n**: BookStack page content + notification text now follow the user's HA language (auto-detect, or explicit de/en in options). Replaces hardcoded German output. Groundwork for HACS-default submission.
2. **Cleaner page titles**: dropped the redundant 'Home Assistant - ' prefix on bundle pages.
3. **Robust migration**: extractor skips nameless devices, sync._needs_move tolerates weird BookStack chapter_id responses. Should resolve the stranded-device-at-book-level case.