### PR TITLE
V0.5.0: Gold quality scale + security review fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,21 +49,20 @@ English supported); you can override it in the options flow.
 
 ## Status
 
-Production-ready for personal use. **V0.4** as of this README:
+Production-ready for personal use. **V0.5** as of this README — first
+release tracking the HA Quality Scale **Gold** tier:
 
 - Full HA-data extraction (areas, devices, entities, automations,
   scripts, scenes, integrations, add-ons)
 - Marker-block merge with hash-based tampering detection
 - Two-pass overview render with internal page links
 - Status sensor, persistent notifications, structured services
-- Reauth flow, area filter, TLS-verify toggle, MQTT-topic display
-- Output language i18n (DE + EN)
+- Reauth flow + user-initiated reconfigure flow (URL / token / TLS)
+- Diagnostics endpoint (redacted dump for bug reports)
+- Area filter, TLS-verify toggle, MQTT-topic display, i18n (DE + EN)
+- Admin-only services (`run_now`, `preview`)
 - 80+ tests covering merge logic, renderer determinism, API client,
-  config flow, coordinator, sync orchestrator (each new bug we shipped
-  has an explicit regression test)
-
-V1 will require: more languages on demand, HA Quality-Scale gold
-checks, full reconfigure flow.
+  config flow, coordinator, sync orchestrator
 
 ## Installation
 
@@ -143,6 +142,112 @@ Each configured BookStack instance gets a sensor:
   `tombstoned`, `skipped_conflict`, `errors`, `total_pages`
 
 Drop it on a dashboard or feed it into automations.
+
+## Use cases
+
+- **House-handover dossier**: when you sell a house or hand it to a
+  caretaker, the wiki already lists every smart device, every area
+  assignment, every automation — pdf-export the book and you have a
+  printable manual.
+- **"Why is this device offline" forensics**: open the device's wiki
+  page, see the manufacturer / model / firmware *and* your manual notes
+  ("replaced battery 2024-10", "needs zigbee re-pairing after router
+  reboot") next to each other.
+- **Onboarding a partner / family member**: the Areas chapter tells
+  them which lights belong to which room, the Automations page tells
+  them what runs at sunset, the manual block under each page is where
+  you explain the intent.
+- **Migration prep**: before flashing a new HA box, the wiki is your
+  out-of-band record of which integrations exist, what they're called,
+  and which entities they own — survives a config restore gone wrong.
+
+## Examples
+
+**Trigger a sync from a button card:**
+
+```yaml
+type: button
+name: Sync wiki
+tap_action:
+  action: call-service
+  service: bookstack_sync.run_now
+```
+
+**Daily sync at 03:00 instead of the built-in interval:**
+
+```yaml
+automation:
+  - alias: BookStack daily sync
+    trigger:
+      - platform: time
+        at: "03:00:00"
+    action:
+      - service: bookstack_sync.run_now
+```
+
+(Set the integration's interval to `manual` first.)
+
+**Notify on sync errors:**
+
+```yaml
+automation:
+  - alias: BookStack sync error
+    trigger:
+      - platform: state
+        entity_id: sensor.bookstack_sync_status
+        to: "error"
+    action:
+      - service: notify.mobile_app_my_phone
+        data:
+          message: >
+            BookStack sync failed:
+            {{ state_attr('sensor.bookstack_sync_status', 'errors') }}
+```
+
+## Troubleshooting
+
+**"BookStack rejected the API token"** — re-create the token in
+BookStack (*My Profile → API Tokens*), make sure it has read+write on
+the target book. The integration will surface a reauth card on the
+Devices & Services page; click it, paste the new ID + secret, done.
+
+**"BookStack unreachable"** — usually one of: wrong URL (forgot the
+port?), TLS verify on against a self-signed cert (toggle it off in
+*Configure*), reverse proxy returning 502 mid-sync (the integration
+retries transient errors three times with exponential backoff — if it
+still fails, the next sync will pick up).
+
+**"AUTO block was edited outside of Home Assistant"** — somebody
+edited the auto section in BookStack. The integration *skips* that
+page rather than clobbering the edit. Either undo the edit in
+BookStack or move the content into the manual block, then re-sync.
+
+**Persistent notification "X errors"** — open the integration's
+Diagnostics dump (gear icon → *Download diagnostics*) and attach it to
+a GitHub issue. The dump redacts the URL + token automatically.
+
+**Pages stuck at book level instead of in their chapter** — known
+finding from v0.1.x; fixed in v0.4.0. If you upgraded, the next sync
+moves them to the right chapter automatically.
+
+## Known limitations
+
+- **One BookStack book per HA instance.** Multiple books are not
+  supported in v0.5; you'd need multiple HA instances.
+- **No bidirectional sync.** Edits in BookStack outside the manual
+  block are detected, logged, and the page is skipped — not merged
+  back into HA.
+- **Sync is HA-state-driven.** Renaming an area or device renames the
+  page on next sync; the old page becomes orphan and gets a tombstone
+  banner. Manual cleanup of tombstoned pages is left to the user.
+- **Languages: DE + EN only.** Other locales fall back to English in
+  the page output. Adding a language is a matter of populating
+  `_strings.py`; PRs welcome.
+- **Excluded areas hide their devices.** A device assigned only to an
+  excluded area disappears from the wiki entirely. If you also want
+  the device, give it a second area outside the excluded set.
+- **API token has full book-level access.** BookStack does not offer
+  per-page tokens; the integration uses whatever the token can reach.
 
 ## Non-goals
 

--- a/custom_components/bookstack_sync/_strings.py
+++ b/custom_components/bookstack_sync/_strings.py
@@ -20,8 +20,6 @@ LANG_DE = "de"
 LANG_EN = "en"
 LANG_DEFAULT = LANG_EN
 
-SUPPORTED_LANGUAGES: tuple[str, ...] = (LANG_DE, LANG_EN)
-
 
 _STRINGS: dict[str, dict[str, str]] = {
     LANG_DE: {
@@ -269,12 +267,3 @@ def get_strings(lang: str | None) -> dict[str, str]:
         if short in _STRINGS:
             return _STRINGS[short]
     return _STRINGS[LANG_DEFAULT]
-
-
-def normalise_language(lang: str | None) -> str:
-    """Return the canonical two-letter code we'd resolve ``lang`` to."""
-    if lang:
-        short = lang.split("-")[0].split("_")[0].lower()
-        if short in _STRINGS:
-            return short
-    return LANG_DEFAULT

--- a/custom_components/bookstack_sync/config_flow.py
+++ b/custom_components/bookstack_sync/config_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 import voluptuous as vol
 from homeassistant import config_entries
@@ -40,6 +41,27 @@ from .const import (
     LOGGER,
     OUTPUT_LANGUAGE_AUTO,
 )
+
+_ERR_INVALID_SCHEME = "base_url_invalid_scheme"
+_ERR_MISSING_HOST = "base_url_missing_host"
+
+
+def _validate_base_url(raw: str) -> str:
+    """
+    Reject schemes other than http/https; reject missing host.
+
+    Why: aiohttp will happily dispatch ``file://``, ``gopher://`` etc. and
+    we send a BookStack token in the Authorization header, so an
+    accidentally-pasted ``file:///etc/passwd`` would otherwise leak the
+    token to a logger or to whatever responds. We do *not* block private
+    IP ranges - 99% of real users run BookStack on 192.168.x.x.
+    """
+    parsed = urlparse(raw.strip())
+    if parsed.scheme not in {"http", "https"}:
+        raise vol.Invalid(_ERR_INVALID_SCHEME)
+    if not parsed.netloc:
+        raise vol.Invalid(_ERR_MISSING_HOST)
+    return raw.strip()
 
 
 def _interval_selector() -> selector.SelectSelector:
@@ -79,6 +101,14 @@ class BookStackSyncConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Collect BookStack URL + API token."""
         errors: dict[str, str] = {}
         if user_input is not None:
+            try:
+                user_input[CONF_BASE_URL] = _validate_base_url(
+                    user_input[CONF_BASE_URL],
+                )
+            except vol.Invalid as err:
+                errors[CONF_BASE_URL] = str(err)
+
+        if user_input is not None and not errors:
             try:
                 books = await self._fetch_books(user_input)
             except BookStackApiAuthError as err:
@@ -203,6 +233,10 @@ class BookStackSyncConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     base_url=existing.data[CONF_BASE_URL],
                     token_id=user_input[CONF_TOKEN_ID],
                     token_secret=user_input[CONF_TOKEN_SECRET],
+                    verify_ssl=existing.data.get(
+                        CONF_VERIFY_SSL,
+                        DEFAULT_VERIFY_SSL,
+                    ),
                 )
             except BookStackApiAuthError as err:
                 LOGGER.warning("Reauth failed: %s", err)
@@ -244,15 +278,109 @@ class BookStackSyncConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         base_url: str,
         token_id: str,
         token_secret: str,
+        *,
+        verify_ssl: bool = DEFAULT_VERIFY_SSL,
     ) -> None:
         """Hit /api/books once to confirm the token works (and is authorised)."""
         client = BookStackApiClient(
             base_url=base_url,
             token_id=token_id,
             token_secret=token_secret,
-            session=async_create_clientsession(self.hass),
+            session=async_create_clientsession(self.hass, verify_ssl=verify_ssl),
         )
         await client.list_books()
+
+    async def async_step_reconfigure(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """
+        User-initiated reconfigure of URL / token / TLS settings.
+
+        Triggered when the user clicks *Configure → Reconfigure* on the
+        integration card. Unlike the options flow this rewrites the
+        ``data`` half of the entry (credentials), not the ``options``.
+        The book selection is preserved as-is.
+        """
+        errors: dict[str, str] = {}
+        existing = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            try:
+                user_input[CONF_BASE_URL] = _validate_base_url(
+                    user_input[CONF_BASE_URL],
+                )
+            except vol.Invalid as err:
+                errors[CONF_BASE_URL] = str(err)
+
+        if user_input is not None and not errors:
+            # Re-pin unique_id; abort if user pointed at a different instance.
+            await self.async_set_unique_id(user_input[CONF_BASE_URL].rstrip("/"))
+            self._abort_if_unique_id_mismatch(reason="url_mismatch")
+
+            try:
+                await self._verify_token(
+                    base_url=user_input[CONF_BASE_URL],
+                    token_id=user_input[CONF_TOKEN_ID],
+                    token_secret=user_input[CONF_TOKEN_SECRET],
+                    verify_ssl=user_input.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
+                )
+            except BookStackApiAuthError as err:
+                LOGGER.warning("Reconfigure auth failed: %s", err)
+                errors["base"] = "auth"
+            except BookStackApiCommunicationError as err:
+                LOGGER.error("BookStack unreachable during reconfigure: %s", err)
+                errors["base"] = "connection"
+            except BookStackApiError:
+                LOGGER.exception("Unexpected error during reconfigure")
+                errors["base"] = "unknown"
+            else:
+                return self.async_update_reload_and_abort(
+                    existing,
+                    data={
+                        **existing.data,
+                        CONF_BASE_URL: user_input[CONF_BASE_URL],
+                        CONF_TOKEN_ID: user_input[CONF_TOKEN_ID],
+                        CONF_TOKEN_SECRET: user_input[CONF_TOKEN_SECRET],
+                        CONF_VERIFY_SSL: user_input.get(
+                            CONF_VERIFY_SSL,
+                            DEFAULT_VERIFY_SSL,
+                        ),
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_BASE_URL,
+                        default=existing.data[CONF_BASE_URL],
+                    ): selector.TextSelector(
+                        selector.TextSelectorConfig(
+                            type=selector.TextSelectorType.URL,
+                        ),
+                    ),
+                    vol.Required(
+                        CONF_TOKEN_ID,
+                        default=existing.data[CONF_TOKEN_ID],
+                    ): selector.TextSelector(),
+                    vol.Required(CONF_TOKEN_SECRET): selector.TextSelector(
+                        selector.TextSelectorConfig(
+                            type=selector.TextSelectorType.PASSWORD,
+                        ),
+                    ),
+                    vol.Required(
+                        CONF_VERIFY_SSL,
+                        default=existing.data.get(
+                            CONF_VERIFY_SSL,
+                            DEFAULT_VERIFY_SSL,
+                        ),
+                    ): selector.BooleanSelector(),
+                },
+            ),
+            errors=errors,
+        )
 
     def _title_for_book(self, book_id: int) -> str:
         for book in self._books:

--- a/custom_components/bookstack_sync/diagnostics.py
+++ b/custom_components/bookstack_sync/diagnostics.py
@@ -1,0 +1,84 @@
+"""
+Diagnostics dump for BookStack Sync.
+
+Triggered when the user clicks ``Download diagnostics`` on the integration
+card in *Settings → Devices & Services → BookStack Sync*.
+
+Returns a redacted snapshot of the entry's config plus the last sync
+report so a bug report can be filed without anyone having to type
+"Lade Diagnose runter und schick die json" three times.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.diagnostics import async_redact_data
+
+from .const import (
+    CONF_BASE_URL,
+    CONF_TOKEN_ID,
+    CONF_TOKEN_SECRET,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from .data import BookStackSyncConfigEntry
+
+
+_REDACT = {CONF_TOKEN_ID, CONF_TOKEN_SECRET, CONF_BASE_URL}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    entry: BookStackSyncConfigEntry,
+) -> dict[str, Any]:
+    """Return a redacted diagnostics dump for one BookStack Sync entry."""
+    runtime = entry.runtime_data
+    coordinator = runtime.coordinator
+    store = runtime.store
+
+    last_run = coordinator.last_run.isoformat() if coordinator.last_run else None
+    last_report = (
+        coordinator.last_report.as_dict()
+        if coordinator.last_report is not None
+        else None
+    )
+
+    # Page mapping summary - we don't dump the full mapping (could be
+    # thousands of entries) but enough that a maintainer can spot whether
+    # the user has e.g. 0 mappings (never synced) vs 400+ (real setup).
+    pages = store.all()
+    chapters = store.all_chapters()
+
+    return {
+        "config": {
+            "data": async_redact_data(dict(entry.data), _REDACT),
+            "options": dict(entry.options),
+        },
+        "ha": {
+            "language": hass.config.language,
+            "version": (
+                hass.config.api.version if getattr(hass.config, "api", None) else None
+            ),
+        },
+        "coordinator": {
+            "last_run": last_run,
+            "last_report": last_report,
+            "is_active": coordinator.update_interval is not None,
+            "update_interval_seconds": (
+                coordinator.update_interval.total_seconds()
+                if coordinator.update_interval
+                else None
+            ),
+        },
+        "store": {
+            "page_count": len(pages),
+            "tombstoned_count": sum(
+                1 for p in pages.values() if p.tombstoned_at is not None
+            ),
+            "chapters": chapters,
+            "sample_keys": sorted(pages.keys())[:10],
+        },
+    }

--- a/custom_components/bookstack_sync/manifest.json
+++ b/custom_components/bookstack_sync/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "service",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dibi73/ha-bookstack-sync/issues",
-  "quality_scale": "silver",
+  "quality_scale": "gold",
   "requirements": [],
-  "version": "0.4.1"
+  "version": "0.5.0"
 }

--- a/custom_components/bookstack_sync/merge.py
+++ b/custom_components/bookstack_sync/merge.py
@@ -39,7 +39,7 @@ _MANUAL_RE = re.compile(
     re.DOTALL,
 )
 
-_DEFAULT_MANUAL_BODY = (
+_FALLBACK_MANUAL_BODY = (
     "\n\n_Notizen, die du hier zwischen den Markern einträgst, "
     "bleiben beim Sync erhalten._\n\n"
 )
@@ -114,21 +114,27 @@ def merge_page(
     new_auto_body: str,
     existing_markdown: str | None,
     last_known_auto_hash: str | None,
+    default_manual_body: str | None = None,
 ) -> MergeResult:
     """
     Combine the new AUTO block with an existing page's MANUAL block.
 
     Detects manual-block tampering inside the AUTO area by comparing the
     existing AUTO block against the hash we stored after the previous write.
+
+    ``default_manual_body`` is the placeholder we drop into the manual
+    block on first write, so users see a hint about where to put their
+    notes. Callers should pass the localised version from ``_strings``;
+    the hardcoded fallback is German for backward compatibility with
+    pre-i18n stores.
     """
     new_hash = hash_auto_block(new_auto_body)
 
     existing_auto = extract_auto_block(existing_markdown)
     existing_manual = extract_manual_block(existing_markdown)
 
-    manual_body = (
-        existing_manual if existing_manual is not None else _DEFAULT_MANUAL_BODY
-    )
+    placeholder = default_manual_body or _FALLBACK_MANUAL_BODY
+    manual_body = existing_manual if existing_manual is not None else placeholder
 
     tampered = (
         existing_auto is not None

--- a/custom_components/bookstack_sync/services.py
+++ b/custom_components/bookstack_sync/services.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from homeassistant.exceptions import Unauthorized
+
 from .const import DOMAIN, LOGGER, SERVICE_PREVIEW, SERVICE_RUN_NOW
 
 if TYPE_CHECKING:
@@ -19,17 +21,41 @@ def _coordinators(hass: HomeAssistant) -> list:
     ]
 
 
+async def _require_admin(hass: HomeAssistant, call: ServiceCall) -> None:
+    """
+    Reject non-admin callers.
+
+    These services trigger writes to an external system and dump page
+    titles (= entity friendly names) into the HA log. We restrict them
+    to admins so a low-privileged user with a long-lived token cannot
+    use them as an enumeration / amplification primitive.
+    """
+    user_id = call.context.user_id
+    if user_id is None:
+        # System-triggered calls (e.g. automation context with no user)
+        # are allowed - the operator owns the automation.
+        return
+    user = await hass.auth.async_get_user(user_id)
+    if user is None or not user.is_admin:
+        raise Unauthorized(
+            context=call.context,
+            permission="bookstack_sync.admin_only",
+        )
+
+
 async def async_register_services(hass: HomeAssistant) -> None:
     """Register run_now and preview as integration-level services."""
     if hass.services.has_service(DOMAIN, SERVICE_RUN_NOW):
         return
 
-    async def _handle_run_now(_call: ServiceCall) -> None:
+    async def _handle_run_now(call: ServiceCall) -> None:
+        await _require_admin(hass, call)
         for coordinator in _coordinators(hass):
             LOGGER.info("Running BookStack sync (run_now)")
             await coordinator.async_run_sync(dry_run=False)
 
-    async def _handle_preview(_call: ServiceCall) -> None:
+    async def _handle_preview(call: ServiceCall) -> None:
+        await _require_admin(hass, call)
         for coordinator in _coordinators(hass):
             LOGGER.info("Running BookStack sync preview (dry-run)")
             report = await coordinator.async_run_sync(dry_run=True)

--- a/custom_components/bookstack_sync/strings.json
+++ b/custom_components/bookstack_sync/strings.json
@@ -26,17 +26,31 @@
           "token_id": "API-Token-ID",
           "token_secret": "API-Token-Secret"
         }
+      },
+      "reconfigure": {
+        "title": "BookStack-Verbindung anpassen",
+        "description": "Ändere URL, Token oder TLS-Einstellung dieser BookStack-Anbindung. Das Ziel-Book und alle Page-Mappings bleiben erhalten. Die URL muss auf dieselbe BookStack-Instanz zeigen wie bisher.",
+        "data": {
+          "base_url": "BookStack-URL",
+          "token_id": "API-Token-ID",
+          "token_secret": "API-Token-Secret",
+          "verify_ssl": "TLS-Zertifikat prüfen (bei Self-Signed deaktivieren)"
+        }
       }
     },
     "error": {
       "auth": "API-Token ungültig oder unzureichende Berechtigungen.",
       "connection": "BookStack-Instanz nicht erreichbar.",
       "no_books": "In dieser BookStack-Instanz wurde kein Book gefunden. Lege zuerst manuell ein Ziel-Book an.",
-      "unknown": "Unbekannter Fehler – siehe Home-Assistant-Log."
+      "unknown": "Unbekannter Fehler – siehe Home-Assistant-Log.",
+      "base_url_invalid_scheme": "URL muss mit http:// oder https:// beginnen.",
+      "base_url_missing_host": "URL ist unvollständig – Hostname fehlt."
     },
     "abort": {
       "already_configured": "Diese BookStack-Instanz ist bereits konfiguriert.",
-      "reauth_successful": "Token aktualisiert – Verbindung zu BookStack steht wieder."
+      "reauth_successful": "Token aktualisiert – Verbindung zu BookStack steht wieder.",
+      "reconfigure_successful": "Verbindung aktualisiert – BookStack-Sync ist neu konfiguriert.",
+      "url_mismatch": "Die neue URL zeigt auf eine andere BookStack-Instanz. Bitte den ursprünglichen Eintrag löschen und neu anlegen."
     }
   },
   "options": {

--- a/custom_components/bookstack_sync/sync.py
+++ b/custom_components/bookstack_sync/sync.py
@@ -263,6 +263,7 @@ async def run_sync(  # noqa: PLR0913 - cohesive entry point
                 page,
                 chapters,
                 report,
+                strings,
                 index=index,
                 total=total_steps,
                 dry_run=dry_run,
@@ -299,6 +300,7 @@ async def run_sync(  # noqa: PLR0913 - cohesive entry point
             overview,
             chapters,
             report,
+            strings,
             index=total_steps,
             total=total_steps,
             dry_run=dry_run,
@@ -367,6 +369,7 @@ async def _sync_one(  # noqa: PLR0913 - cohesive sync step, splitting hurts clar
     page: _PlannedPage,
     chapters: dict[str, int],
     report: SyncReport,
+    strings: dict[str, str],
     *,
     index: int,
     total: int,
@@ -424,6 +427,7 @@ async def _sync_one(  # noqa: PLR0913 - cohesive sync step, splitting hurts clar
         new_auto_body=page.auto_body,
         existing_markdown=existing_markdown,
         last_known_auto_hash=mapping.auto_block_hash or None,
+        default_manual_body=strings.get("default_manual_body"),
     )
 
     if merged.manual_block_tampered:
@@ -558,6 +562,7 @@ async def _tombstone_one(  # noqa: PLR0913 - cohesive sync step
         new_auto_body=auto_body,
         existing_markdown=existing_markdown,
         last_known_auto_hash=mapping.auto_block_hash or None,
+        default_manual_body=strings.get("default_manual_body"),
     )
 
     if merged.manual_block_tampered:

--- a/custom_components/bookstack_sync/translations/de.json
+++ b/custom_components/bookstack_sync/translations/de.json
@@ -26,17 +26,31 @@
           "token_id": "API-Token-ID",
           "token_secret": "API-Token-Secret"
         }
+      },
+      "reconfigure": {
+        "title": "BookStack-Verbindung anpassen",
+        "description": "Ändere URL, Token oder TLS-Einstellung dieser BookStack-Anbindung. Das Ziel-Book und alle Page-Mappings bleiben erhalten. Die URL muss auf dieselbe BookStack-Instanz zeigen wie bisher.",
+        "data": {
+          "base_url": "BookStack-URL",
+          "token_id": "API-Token-ID",
+          "token_secret": "API-Token-Secret",
+          "verify_ssl": "TLS-Zertifikat prüfen (bei Self-Signed deaktivieren)"
+        }
       }
     },
     "error": {
       "auth": "API-Token ungültig oder unzureichende Berechtigungen.",
       "connection": "BookStack-Instanz nicht erreichbar.",
       "no_books": "In dieser BookStack-Instanz wurde kein Book gefunden. Lege zuerst manuell ein Ziel-Book an.",
-      "unknown": "Unbekannter Fehler – siehe Home-Assistant-Log."
+      "unknown": "Unbekannter Fehler – siehe Home-Assistant-Log.",
+      "base_url_invalid_scheme": "URL muss mit http:// oder https:// beginnen.",
+      "base_url_missing_host": "URL ist unvollständig – Hostname fehlt."
     },
     "abort": {
       "already_configured": "Diese BookStack-Instanz ist bereits konfiguriert.",
-      "reauth_successful": "Token aktualisiert – Verbindung zu BookStack steht wieder."
+      "reauth_successful": "Token aktualisiert – Verbindung zu BookStack steht wieder.",
+      "reconfigure_successful": "Verbindung aktualisiert – BookStack-Sync ist neu konfiguriert.",
+      "url_mismatch": "Die neue URL zeigt auf eine andere BookStack-Instanz. Bitte den ursprünglichen Eintrag löschen und neu anlegen."
     }
   },
   "options": {

--- a/custom_components/bookstack_sync/translations/en.json
+++ b/custom_components/bookstack_sync/translations/en.json
@@ -26,17 +26,31 @@
           "token_id": "API token ID",
           "token_secret": "API token secret"
         }
+      },
+      "reconfigure": {
+        "title": "Adjust BookStack connection",
+        "description": "Change URL, token or TLS setting for this BookStack link. The target book and all page mappings are preserved. The URL must point at the same BookStack instance as before.",
+        "data": {
+          "base_url": "BookStack URL",
+          "token_id": "API token ID",
+          "token_secret": "API token secret",
+          "verify_ssl": "Verify TLS certificate (disable for self-signed)"
+        }
       }
     },
     "error": {
       "auth": "API token rejected or missing permissions.",
       "connection": "Cannot reach BookStack.",
       "no_books": "No book found in this BookStack instance. Create a target book first.",
-      "unknown": "Unexpected error - check the Home Assistant log."
+      "unknown": "Unexpected error - check the Home Assistant log.",
+      "base_url_invalid_scheme": "URL must start with http:// or https://.",
+      "base_url_missing_host": "URL is incomplete - hostname missing."
     },
     "abort": {
       "already_configured": "This BookStack instance is already configured.",
-      "reauth_successful": "Token refreshed - BookStack connection restored."
+      "reauth_successful": "Token refreshed - BookStack connection restored.",
+      "reconfigure_successful": "Connection updated - BookStack Sync has been reconfigured.",
+      "url_mismatch": "The new URL points at a different BookStack instance. Please remove the original entry and add it fresh."
     }
   },
   "options": {


### PR DESCRIPTION
## Summary

- **Critical**: fix Python 2 `except` syntax in `sync.py:_needs_move` — module would not import on a path with a non-numeric `chapter_id` from BookStack (release blocker).
- **Gold quality scale**: user-initiated reconfigure flow (URL / token / TLS), redacted diagnostics endpoint, `py.typed` marker, expanded README (Use cases / Examples / Troubleshooting / Known limitations).
- **Security review hardening**: SSRF guard on `base_url` (scheme + host check), admin-only `run_now`/`preview` services, diagnostics `_REDACT` now uses the `CONF_BASE_URL` constant, reauth respects entry's stored `verify_ssl`.
- **i18n bug fix**: `merge_page` now accepts `default_manual_body`; English wikis no longer get a hardcoded German placeholder on first write.
- **Dead code**: removed unused `SUPPORTED_LANGUAGES` + `normalise_language`.

Two security findings deferred to v0.5.1 (tracked, not fixed here): markdown link-context escaping in `renderer.py`, BookStack URL appearing in error logs (token is *not* in logs — it's in the `Authorization` header).

## Test plan

- [ ] CI: ruff + pytest all green
- [ ] Manual: HACS install on a test HA, complete config flow with a malformed URL (`file:///etc/passwd`) → expect inline error
- [ ] Manual: open *Configure → Reconfigure*, change token, save → entry reloads with new credentials
- [ ] Manual: download diagnostics → confirm `base_url`, `token_id`, `token_secret` redacted
- [ ] Manual: as a non-admin HA user, attempt `bookstack_sync.run_now` → expect Unauthorized

🤖 Generated with [Claude Code](https://claude.com/claude-code)