### PR TITLE
V0.5.1: syncing-state sensor + markdown link escape + URL log scrubbing

### DIFF
--- a/custom_components/bookstack_sync/api.py
+++ b/custom_components/bookstack_sync/api.py
@@ -6,6 +6,7 @@ import asyncio
 import socket
 from http import HTTPStatus
 from typing import Any
+from urllib.parse import urlparse
 
 import aiohttp
 
@@ -71,6 +72,25 @@ class BookStackApiClient:
     def base_url(self) -> str:
         """Return the BookStack base URL without trailing slash."""
         return self._base_url
+
+    def _scrub(self, err: Exception) -> str:
+        """
+        Return a stringified ``err`` with the BookStack URL / hostname masked.
+
+        Why: aiohttp's ``ClientResponseError`` includes the full request URL
+        in its repr; ``socket.gaierror`` includes the hostname. Both end up
+        in ``home-assistant.log`` via ``LOGGER.exception`` and via
+        ``UpdateFailed(str(err))`` rendered in HA's notifications. The token
+        itself never travels via URL (it's in the ``Authorization`` header),
+        but the hostname is potentially private and has no place leaking
+        into logs the user might paste into a forum.
+        """
+        text = str(err)
+        text = text.replace(self._base_url, "<bookstack>")
+        host = urlparse(self._base_url).hostname
+        if host:
+            text = text.replace(host, "<bookstack>")
+        return text
 
     async def list_books(self) -> list[dict[str, Any]]:
         """Return all books visible to the configured token."""
@@ -207,20 +227,21 @@ class BookStackApiClient:
                         path,
                         attempt + 1,
                         MAX_REQUEST_ATTEMPTS,
-                        err,
+                        self._scrub(err),
                         backoff,
                     )
                     await asyncio.sleep(backoff)
                     continue
                 msg = (
                     f"BookStack request failed after {MAX_REQUEST_ATTEMPTS} "
-                    f"attempts: {err}"
+                    f"attempts: {self._scrub(err)}"
                 )
                 raise BookStackApiCommunicationError(msg) from err
             except (aiohttp.ClientError, socket.gaierror) as err:
-                msg = f"BookStack request failed: {err}"
+                msg = f"BookStack request failed: {self._scrub(err)}"
                 raise BookStackApiCommunicationError(msg) from err
         # The retry loop above either returns, raises, or reaches its final
         # iteration which always raises. This line is purely a safety net.
-        msg = f"BookStack request retry loop exited unexpectedly: {last_err}"
+        scrubbed = self._scrub(last_err) if last_err else "no error captured"
+        msg = f"BookStack request retry loop exited unexpectedly: {scrubbed}"
         raise BookStackApiCommunicationError(msg)

--- a/custom_components/bookstack_sync/coordinator.py
+++ b/custom_components/bookstack_sync/coordinator.py
@@ -60,6 +60,10 @@ class BookStackSyncCoordinator(DataUpdateCoordinator[SyncReport]):
         self.config_entry = entry
         self.last_run: datetime | None = None
         self.last_report: SyncReport | None = None
+        # Surfaced via the status sensor so the dashboard can show
+        # "syncing" while a run is in progress. Toggled in
+        # ``async_run_sync`` (try/finally so failed runs also clear it).
+        self.is_syncing: bool = False
         # Serialises every sync path - schedule, run_now service, preview -
         # so they cannot interleave and create duplicate pages on first run.
         self._sync_lock = asyncio.Lock()
@@ -75,28 +79,34 @@ class BookStackSyncCoordinator(DataUpdateCoordinator[SyncReport]):
     async def async_run_sync(self, *, dry_run: bool = False) -> SyncReport:
         """Execute a sync immediately, regardless of the schedule."""
         async with self._sync_lock:
-            runtime = self.config_entry.runtime_data
-            options = self.config_entry.options
-            data = self.config_entry.data
-            # Initial setup stores book_id in `data`, but the options flow
-            # rewrites it into `options`. Look in options first, then fall
-            # back to data so both layouts work without crashing.
-            book_id = int(options.get(CONF_BOOK_ID) or data[CONF_BOOK_ID])
-            excluded_areas = options.get(CONF_EXCLUDED_AREAS, []) or []
-            strings = get_strings(self._resolve_output_language())
-            report = await run_sync(
-                self.hass,
-                runtime.client,
-                runtime.store,
-                book_id,
-                strings,
-                dry_run=dry_run,
-                excluded_area_ids=excluded_areas,
-            )
-            if not dry_run:
-                self.last_run = datetime.now(tz=UTC)
-                self.last_report = report
-            return report
+            self.is_syncing = True
+            self.async_update_listeners()
+            try:
+                runtime = self.config_entry.runtime_data
+                options = self.config_entry.options
+                data = self.config_entry.data
+                # Initial setup stores book_id in `data`, but the options
+                # flow rewrites it into `options`. Look in options first,
+                # then fall back to data so both layouts work.
+                book_id = int(options.get(CONF_BOOK_ID) or data[CONF_BOOK_ID])
+                excluded_areas = options.get(CONF_EXCLUDED_AREAS, []) or []
+                strings = get_strings(self._resolve_output_language())
+                report = await run_sync(
+                    self.hass,
+                    runtime.client,
+                    runtime.store,
+                    book_id,
+                    strings,
+                    dry_run=dry_run,
+                    excluded_area_ids=excluded_areas,
+                )
+                if not dry_run:
+                    self.last_run = datetime.now(tz=UTC)
+                    self.last_report = report
+                return report
+            finally:
+                self.is_syncing = False
+                self.async_update_listeners()
 
     def _resolve_output_language(self) -> str:
         """

--- a/custom_components/bookstack_sync/manifest.json
+++ b/custom_components/bookstack_sync/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dibi73/ha-bookstack-sync/issues",
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.5.0"
+  "version": "0.5.1"
 }

--- a/custom_components/bookstack_sync/renderer.py
+++ b/custom_components/bookstack_sync/renderer.py
@@ -47,12 +47,20 @@ def _md_escape(value: str) -> str:
     BookStack renders markdown safely by default but we don't want a device
     named ``Living Room | <script>`` to either break the table layout or end
     up as an inline HTML tag if a user enables raw-HTML in BookStack.
+
+    ``[`` / ``]`` are escaped to defuse a name like
+    ``Lampe](javascript:alert(1))`` from breaking out of a markdown link
+    label and injecting a clickable ``javascript:`` URL. BookStack's own
+    sanitiser strips ``javascript:`` schemes on render, but treating that
+    as defence-in-depth lets us not depend on it.
     """
     if not value:
         return value
     return (
         value.replace("\\", "\\\\")
         .replace("|", "\\|")
+        .replace("[", "\\[")
+        .replace("]", "\\]")
         .replace("<", "&lt;")
         .replace(">", "&gt;")
         .replace("\n", " ")

--- a/custom_components/bookstack_sync/sensor.py
+++ b/custom_components/bookstack_sync/sensor.py
@@ -32,9 +32,9 @@ class BookStackSyncStatusSensor(CoordinatorEntity, SensorEntity):
     """
     Surfaces the result of the last sync run as a single sensor entity.
 
-    The state is one of ``ok`` / ``error`` / ``never_run``; the counts and the
-    last-run timestamp live as attributes so they can be put on a dashboard
-    or used in automations.
+    The state is one of ``ok`` / ``error`` / ``never_run`` / ``syncing``;
+    the counts and the last-run timestamp live as attributes so they can
+    be put on a dashboard or used in automations.
     """
 
     _attr_attribution = ATTRIBUTION
@@ -57,7 +57,9 @@ class BookStackSyncStatusSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def native_value(self) -> str:
-        """Top-level status: ``ok``, ``error`` or ``never_run``."""
+        """Top-level status: ``syncing``, ``ok``, ``error`` or ``never_run``."""
+        if self.coordinator.is_syncing:
+            return "syncing"
         report = self.coordinator.last_report
         if report is None:
             return "never_run"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -241,3 +241,38 @@ class TestRetryOnTransientErrors:
             )
             with pytest.raises(BookStackApiCommunicationError):
                 await client.get_page(42)
+
+
+class TestUrlScrubbing:
+    """The BookStack URL/hostname must not leak into raised error messages."""
+
+    async def test_500_error_message_does_not_contain_url_or_host(
+        self,
+        client: BookStackApiClient,
+    ) -> None:
+        with aioresponses() as mocked:
+            mocked.get(
+                "http://bookstack.local:6875/api/pages/42",
+                status=500,
+            )
+            with pytest.raises(BookStackApiCommunicationError) as excinfo:
+                await client.get_page(42)
+            text = str(excinfo.value)
+            assert "bookstack.local" not in text
+            assert "http://bookstack.local:6875" not in text
+            # Sanity: scrubbed placeholder is in there instead.
+            assert "<bookstack>" in text
+
+    async def test_persistent_disconnect_message_does_not_leak_host(
+        self,
+        client: BookStackApiClient,
+    ) -> None:
+        with aioresponses() as mocked:
+            for _ in range(MAX_REQUEST_ATTEMPTS):
+                mocked.get(
+                    "http://bookstack.local:6875/api/pages/42",
+                    exception=aiohttp.ServerDisconnectedError(),
+                )
+            with pytest.raises(BookStackApiCommunicationError) as excinfo:
+                await client.get_page(42)
+            assert "bookstack.local" not in str(excinfo.value)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -117,6 +117,61 @@ async def test_last_run_recorded_after_successful_sync(
     assert coord.last_report is report
 
 
+async def test_is_syncing_flag_set_during_run(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """The is_syncing flag is True during run_sync, False before/after."""
+    config_entry.add_to_hass(hass)
+    coord = _make_coordinator(hass, config_entry)
+    config_entry.runtime_data = type(
+        "RD",
+        (),
+        {"client": object(), "store": object()},
+    )()
+
+    flag_during = []
+
+    async def fake_run_sync(*args: object, **kwargs: object) -> SyncReport:
+        flag_during.append(coord.is_syncing)
+        return SyncReport(dry_run=bool(kwargs.get("dry_run")))
+
+    assert coord.is_syncing is False
+    with patch(
+        "custom_components.bookstack_sync.coordinator.run_sync",
+        new=fake_run_sync,
+    ):
+        await coord.async_run_sync()
+
+    assert flag_during == [True]
+    assert coord.is_syncing is False
+
+
+async def test_is_syncing_flag_cleared_on_failure(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """A failed run also clears is_syncing (try/finally)."""
+    config_entry.add_to_hass(hass)
+    coord = _make_coordinator(hass, config_entry)
+    config_entry.runtime_data = type(
+        "RD",
+        (),
+        {"client": object(), "store": object()},
+    )()
+
+    with (
+        patch(
+            "custom_components.bookstack_sync.coordinator.run_sync",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ),
+        pytest.raises(RuntimeError),
+    ):
+        await coord.async_run_sync()
+
+    assert coord.is_syncing is False
+
+
 async def test_dry_run_does_not_record_last_run(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -109,6 +109,21 @@ class TestMdEscape:
     def test_no_special_chars_unchanged(self) -> None:
         assert _md_escape("Living Room") == "Living Room"
 
+    def test_square_brackets_escaped(self) -> None:
+        # Defence-in-depth against link-label breakout: a device named
+        # ``Lampe](javascript:alert(1))`` must not break out of
+        # ``[label](page:N)`` and inject a clickable javascript: URL.
+        assert _md_escape("Lampe](javascript:alert(1))") == (
+            "Lampe\\](javascript:alert(1))"
+        )
+        assert _md_escape("[note]") == "\\[note\\]"
+
+    def test_link_label_breakout_defused(self) -> None:
+        # End-to-end: a rendered link must not contain an unescaped
+        # ``](javascript:`` sequence regardless of input.
+        rendered = f"[{_md_escape('Lampe](javascript:alert(1))')}](page:42)"
+        assert "](javascript:" not in rendered
+
 
 class TestDeterminism:
     """Same input must produce byte-identical output across calls."""

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -119,10 +119,20 @@ class TestMdEscape:
         assert _md_escape("[note]") == "\\[note\\]"
 
     def test_link_label_breakout_defused(self) -> None:
-        # End-to-end: a rendered link must not contain an unescaped
-        # ``](javascript:`` sequence regardless of input.
+        # End-to-end: when a malicious name is rendered into a markdown
+        # link, the close-bracket of the malicious name must arrive in the
+        # output as ``\]`` (backslash-escaped), so the markdown parser
+        # treats it as a literal character and does NOT close the link
+        # label early. The naive ``](javascript:`` substring is still
+        # present in the raw text (because ``\]`` followed by ``(`` reads
+        # as ``](`` if you ignore the backslash) — what matters is that
+        # the parser sees ``\]``, not a real link terminator.
         rendered = f"[{_md_escape('Lampe](javascript:alert(1))')}](page:42)"
-        assert "](javascript:" not in rendered
+        assert "\\]" in rendered, "close-bracket must be escaped"
+        # And the unescaped ``](`` only appears at the legitimate link
+        # boundary at the very end (``](page:42)``).
+        assert rendered.count("](") == 1
+        assert rendered.endswith("](page:42)")
 
 
 class TestDeterminism:

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -120,18 +120,15 @@ class TestMdEscape:
 
     def test_link_label_breakout_defused(self) -> None:
         # End-to-end: when a malicious name is rendered into a markdown
-        # link, the close-bracket of the malicious name must arrive in the
-        # output as ``\]`` (backslash-escaped), so the markdown parser
+        # link, the close-bracket of the malicious name must arrive in
+        # the output as ``\]`` (backslash-escaped) so the markdown parser
         # treats it as a literal character and does NOT close the link
-        # label early. The naive ``](javascript:`` substring is still
-        # present in the raw text (because ``\]`` followed by ``(`` reads
-        # as ``](`` if you ignore the backslash) — what matters is that
-        # the parser sees ``\]``, not a real link terminator.
+        # label early. Note: the substring ``](`` is still present in the
+        # raw text (``\]`` followed by ``(`` shares the two characters
+        # ``](`` if you ignore the backslash) — what matters is the
+        # parser sees the backslash, not a real link terminator.
         rendered = f"[{_md_escape('Lampe](javascript:alert(1))')}](page:42)"
         assert "\\]" in rendered, "close-bracket must be escaped"
-        # And the unescaped ``](`` only appears at the legitimate link
-        # boundary at the very end (``](page:42)``).
-        assert rendered.count("](") == 1
         assert rendered.endswith("](page:42)")
 
 


### PR DESCRIPTION
## Summary

- **#19 fix**: status sensor now emits the documented `syncing` state during an active run (was only ever showing `ok` / `error` / `never_run`).
- **#16 hardening (markdown escape)**: `_md_escape` escapes `[` / `]` so a malicious entity name like `Lampe](javascript:alert(1))` cannot break out of `[label](page:N)` link syntax. Defence-in-depth — BookStack already strips `javascript:` schemes.
- **#16 hardening (URL log scrub)**: `BookStackApiClient._scrub` masks `base_url` and hostname in error messages before they reach `LOGGER.exception` or HA notifications. The token itself never appeared in URLs (only in the `Authorization` header).

Closes #16, #19.

## Test plan

- [ ] CI: ruff + pytest green
- [ ] Manual: trigger `bookstack_sync.run_now`, dashboard sensor briefly shows `syncing` then settles back to `ok`
- [ ] Manual: stop BookStack, run sync, confirm `home-assistant.log` shows `<bookstack>` instead of the actual hostname in the error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)