### PR TITLE
V0.8.1: prefer LAN-IP over WAN-IP on routers / gateways

### DIFF
--- a/custom_components/bookstack_sync/extractor.py
+++ b/custom_components/bookstack_sync/extractor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -614,6 +615,24 @@ def _build_network_info(
     )
 
 
+def _is_private_ip(ip: str | None) -> bool:
+    """
+    Return ``True`` when ``ip`` is in an RFC1918 / link-local range.
+
+    Used to prefer LAN-side IPs over WAN-side ones when ranking the
+    connections of a router / gateway. WAN IPs change frequently with
+    DHCP from the ISP and are operationally less interesting than the
+    static internal management IP.
+    """
+    if not ip:
+        return False
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return False
+    return addr.is_private or addr.is_link_local
+
+
 def _populate_network_info(
     device_snap: DeviceSnapshot,
     device_reg: dr.DeviceRegistry,
@@ -624,7 +643,10 @@ def _populate_network_info(
     Strategy:
     1. For every ``device_tracker.*`` entity attached to this device, build
        a ``NetworkInfo`` from its state attributes.
-    2. Sort by ``last_seen`` desc — primary connection (most recent) first.
+    2. Sort: private (RFC1918 / link-local) IPs first, then by
+       ``last_seen`` desc within each group. Routers / gateways have both
+       a public WAN IP and a private LAN IP; the LAN one is always the
+       useful one for documentation purposes.
     3. If no tracker carried useful data, fall back to a MAC-only NetworkInfo
        sourced from the device-registry's ``connections`` set (Zigbee /
        Matter devices often have a MAC there but no live tracker).
@@ -641,7 +663,14 @@ def _populate_network_info(
         if info:
             infos.append(info)
 
+    # Two-pass stable sort: first break ties by last_seen desc (most
+    # recent first), then prepend the private-IP entries. End result:
+    # private IPs in last-seen-desc order, then non-private IPs in
+    # last-seen-desc order. Critical for routers / gateways which carry
+    # both a public WAN IP and a private LAN IP — the LAN one is always
+    # the useful one for documentation.
     infos.sort(key=lambda i: i.last_seen or "", reverse=True)
+    infos.sort(key=lambda i: 0 if _is_private_ip(i.ip) else 1)
 
     if not infos and fallback_macs:
         infos = [

--- a/custom_components/bookstack_sync/manifest.json
+++ b/custom_components/bookstack_sync/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dibi73/ha-bookstack-sync/issues",
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.8.0"
+  "version": "0.8.1"
 }

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -337,3 +337,67 @@ async def test_device_with_multiple_trackers_primary_first(
     assert len(nuc_snap.network_extra) == 1
     assert nuc_snap.network_extra[0].ip == "192.168.1.10"
     assert nuc_snap.network_extra[0].connection_type == "wired"
+
+
+async def test_router_prefers_private_ip_over_wan(hass: HomeAssistant) -> None:
+    """A device with two trackers (WAN + LAN) shows the LAN IP as primary.
+
+    Regression for issue #37: routers / gateways have a public WAN IP
+    that's frequently fresher (ISP heartbeats) and used to win the
+    ``last_seen`` race. The LAN IP is always the documentation-relevant
+    one even when last-seen older.
+    """
+    entry = MockConfigEntry(domain="unifi", entry_id="entry_unifi", title="UniFi")
+    entry.add_to_hass(hass)
+    device_reg = dr.async_get(hass)
+    entity_reg = er.async_get(hass)
+
+    gateway = device_reg.async_get_or_create(
+        config_entry_id="entry_unifi",
+        identifiers={("unifi", "udm")},
+        name="UDM Pro",
+        model="UDM-Pro",
+        manufacturer="Ubiquiti",
+    )
+    wan_tracker = entity_reg.async_get_or_create(
+        domain="device_tracker",
+        platform="unifi",
+        unique_id="udm_wan",
+        device_id=gateway.id,
+        suggested_object_id="udm_wan",
+    )
+    lan_tracker = entity_reg.async_get_or_create(
+        domain="device_tracker",
+        platform="unifi",
+        unique_id="udm_lan",
+        device_id=gateway.id,
+        suggested_object_id="udm_lan",
+    )
+    # WAN tracker has a fresher last_seen — would win without the fix.
+    hass.states.async_set(
+        wan_tracker.entity_id,
+        "home",
+        {
+            "ip": "85.20.30.40",
+            "mac": "aa:bb:cc:dd:ee:ff",
+            "last_seen": "2026-04-30T20:00:00",
+        },
+    )
+    hass.states.async_set(
+        lan_tracker.entity_id,
+        "home",
+        {
+            "ip": "192.168.1.1",
+            "mac": "11:22:33:44:55:66",
+            "last_seen": "2026-04-30T19:00:00",
+        },
+    )
+
+    snap = extract_snapshot(hass)
+    udm = next(d for d in snap.unassigned_devices if d.name == "UDM Pro")
+    # Primary must be the private LAN IP, despite older last_seen.
+    assert udm.network is not None
+    assert udm.network.ip == "192.168.1.1"
+    # Extra contains the WAN IP.
+    assert len(udm.network_extra) == 1
+    assert udm.network_extra[0].ip == "85.20.30.40"


### PR DESCRIPTION
Closes #37.

## Bug

Bei Routern (UDM / USG / Cloud Gateway / FRITZ!Box) hat das Gerät zwei IPs — eine externe (WAN, wechselnd) und eine interne (LAN, statisch). Aktuell wurde die WAN-IP als Primary auf der Device-Page angezeigt, weil ihr Tracker frischer war (ISP-Heartbeats). Die LAN-IP ist aber das Doku-relevante.

## Fix

Two-pass stable sort in ``_populate_network_info``:
1. Erst nach ``last_seen`` desc
2. Dann nach ``is_private`` (private IPs zuerst)

Resultat: **private IPs** (RFC1918 + link-local) zuerst, jeweils nach ``last_seen`` desc innerhalb der Gruppe sortiert.

WAN-IP wandert in ``network_extra`` und erscheint als ``(auch: ...)`` — sichtbar, aber nicht mehr Primary.

Regression-Test in ``test_extractor.py``: simuliert UDM-Pro mit WAN-Tracker (frischer, public IP) + LAN-Tracker (älter, 192.168.x) und stellt sicher dass die LAN-IP als Primary gewinnt.

## Test plan
- [ ] CI grün
- [ ] Manual auf UniFi-Setup mit UDM/USG: Gateway-Page zeigt jetzt LAN-IP