### PR TITLE
V0.8.2: fix empty Automatisierungen/Skripte/Szenen bundles

### DIFF
--- a/custom_components/bookstack_sync/extractor.py
+++ b/custom_components/bookstack_sync/extractor.py
@@ -402,7 +402,8 @@ def _automation_entity_ids(
     hass: HomeAssistant,
     entity_reg: er.EntityRegistry,
 ) -> set[str]:
-    """Union of entity_ids in registry + state-machine for one domain.
+    """
+    Return union of entity_ids in registry + state-machine.
 
     Walking only the entity_registry misses YAML-defined automations
     that show up in ``hass.states`` but not the registry; walking only

--- a/custom_components/bookstack_sync/extractor.py
+++ b/custom_components/bookstack_sync/extractor.py
@@ -398,36 +398,52 @@ def _entity_area(
     return entry.area_id if entry else None
 
 
+def _automation_entity_ids(
+    hass: HomeAssistant,
+    entity_reg: er.EntityRegistry,
+) -> set[str]:
+    """Union of entity_ids in registry + state-machine for one domain.
+
+    Walking only the entity_registry misses YAML-defined automations
+    that show up in ``hass.states`` but not the registry; walking only
+    ``hass.states`` misses disabled automations + ones lost to startup
+    race conditions. Union of both (issue #39).
+    """
+    ids: set[str] = {
+        e.entity_id
+        for e in entity_reg.entities.values()
+        if e.entity_id.startswith("automation.")
+    }
+    ids.update(s.entity_id for s in hass.states.async_all("automation"))
+    return ids
+
+
 def _extract_automations(
     hass: HomeAssistant,
     entity_reg: er.EntityRegistry,
 ) -> list[AutomationSnapshot]:
     automations: list[AutomationSnapshot] = []
-    # Walk the entity registry rather than hass.states so we also capture
-    # disabled automations and survive the early-startup race where
-    # automations exist in the registry but their states haven't been
-    # hydrated yet (issue #39).
-    for entry in entity_reg.entities.values():
-        if not entry.entity_id.startswith("automation."):
-            continue
-        state_obj = hass.states.get(entry.entity_id)
+    for entity_id in _automation_entity_ids(hass, entity_reg):
+        registry_entry = entity_reg.async_get(entity_id)
+        state_obj = hass.states.get(entity_id)
         attrs = state_obj.attributes if state_obj else {}
         last = attrs.get("last_triggered")
         name = (
-            entry.name
-            or entry.original_name
+            (registry_entry.name if registry_entry else None)
+            or (registry_entry.original_name if registry_entry else None)
             or attrs.get("friendly_name")
-            or entry.entity_id
+            or entity_id
         )
+        area_id = registry_entry.area_id if registry_entry else None
         automations.append(
             AutomationSnapshot(
-                entity_id=entry.entity_id,
+                entity_id=entity_id,
                 name=name,
                 description=attrs.get("description") or None,
                 state=state_obj.state if state_obj else "disabled",
                 mode=attrs.get("mode"),
                 last_triggered=last.isoformat() if hasattr(last, "isoformat") else last,
-                area_id=entry.area_id,
+                area_id=area_id,
             ),
         )
     automations.sort(key=lambda a: (a.name.lower(), a.entity_id))
@@ -439,28 +455,32 @@ def _extract_scripts(
     entity_reg: er.EntityRegistry,
 ) -> list[ScriptSnapshot]:
     scripts: list[ScriptSnapshot] = []
-    # See _extract_automations: entity-registry walk catches disabled
-    # entries + survives startup race (issue #39).
-    for entry in entity_reg.entities.values():
-        if not entry.entity_id.startswith("script."):
-            continue
-        state_obj = hass.states.get(entry.entity_id)
+    ids: set[str] = {
+        e.entity_id
+        for e in entity_reg.entities.values()
+        if e.entity_id.startswith("script.")
+    }
+    ids.update(s.entity_id for s in hass.states.async_all("script"))
+    for entity_id in ids:
+        registry_entry = entity_reg.async_get(entity_id)
+        state_obj = hass.states.get(entity_id)
         attrs = state_obj.attributes if state_obj else {}
         last = attrs.get("last_triggered")
         name = (
-            entry.name
-            or entry.original_name
+            (registry_entry.name if registry_entry else None)
+            or (registry_entry.original_name if registry_entry else None)
             or attrs.get("friendly_name")
-            or entry.entity_id
+            or entity_id
         )
+        area_id = registry_entry.area_id if registry_entry else None
         scripts.append(
             ScriptSnapshot(
-                entity_id=entry.entity_id,
+                entity_id=entity_id,
                 name=name,
                 description=attrs.get("description") or None,
                 state=state_obj.state if state_obj else "disabled",
                 last_triggered=last.isoformat() if hasattr(last, "isoformat") else last,
-                area_id=entry.area_id,
+                area_id=area_id,
             ),
         )
     scripts.sort(key=lambda s: (s.name.lower(), s.entity_id))
@@ -472,23 +492,28 @@ def _extract_scenes(
     entity_reg: er.EntityRegistry,
 ) -> list[SceneSnapshot]:
     scenes: list[SceneSnapshot] = []
-    # See _extract_automations: entity-registry walk (issue #39).
-    for entry in entity_reg.entities.values():
-        if not entry.entity_id.startswith("scene."):
-            continue
-        state_obj = hass.states.get(entry.entity_id)
+    ids: set[str] = {
+        e.entity_id
+        for e in entity_reg.entities.values()
+        if e.entity_id.startswith("scene.")
+    }
+    ids.update(s.entity_id for s in hass.states.async_all("scene"))
+    for entity_id in ids:
+        registry_entry = entity_reg.async_get(entity_id)
+        state_obj = hass.states.get(entity_id)
         attrs = state_obj.attributes if state_obj else {}
         name = (
-            entry.name
-            or entry.original_name
+            (registry_entry.name if registry_entry else None)
+            or (registry_entry.original_name if registry_entry else None)
             or attrs.get("friendly_name")
-            or entry.entity_id
+            or entity_id
         )
+        area_id = registry_entry.area_id if registry_entry else None
         scenes.append(
             SceneSnapshot(
-                entity_id=entry.entity_id,
+                entity_id=entity_id,
                 name=name,
-                area_id=entry.area_id,
+                area_id=area_id,
             ),
         )
     scenes.sort(key=lambda s: (s.name.lower(), s.entity_id))

--- a/custom_components/bookstack_sync/extractor.py
+++ b/custom_components/bookstack_sync/extractor.py
@@ -403,18 +403,31 @@ def _extract_automations(
     entity_reg: er.EntityRegistry,
 ) -> list[AutomationSnapshot]:
     automations: list[AutomationSnapshot] = []
-    for state in hass.states.async_all("automation"):
-        attrs = state.attributes
+    # Walk the entity registry rather than hass.states so we also capture
+    # disabled automations and survive the early-startup race where
+    # automations exist in the registry but their states haven't been
+    # hydrated yet (issue #39).
+    for entry in entity_reg.entities.values():
+        if not entry.entity_id.startswith("automation."):
+            continue
+        state_obj = hass.states.get(entry.entity_id)
+        attrs = state_obj.attributes if state_obj else {}
         last = attrs.get("last_triggered")
+        name = (
+            entry.name
+            or entry.original_name
+            or attrs.get("friendly_name")
+            or entry.entity_id
+        )
         automations.append(
             AutomationSnapshot(
-                entity_id=state.entity_id,
-                name=attrs.get("friendly_name") or state.entity_id,
+                entity_id=entry.entity_id,
+                name=name,
                 description=attrs.get("description") or None,
-                state=state.state,
+                state=state_obj.state if state_obj else "disabled",
                 mode=attrs.get("mode"),
                 last_triggered=last.isoformat() if hasattr(last, "isoformat") else last,
-                area_id=_entity_area(entity_reg, state.entity_id),
+                area_id=entry.area_id,
             ),
         )
     automations.sort(key=lambda a: (a.name.lower(), a.entity_id))
@@ -426,17 +439,28 @@ def _extract_scripts(
     entity_reg: er.EntityRegistry,
 ) -> list[ScriptSnapshot]:
     scripts: list[ScriptSnapshot] = []
-    for state in hass.states.async_all("script"):
-        attrs = state.attributes
+    # See _extract_automations: entity-registry walk catches disabled
+    # entries + survives startup race (issue #39).
+    for entry in entity_reg.entities.values():
+        if not entry.entity_id.startswith("script."):
+            continue
+        state_obj = hass.states.get(entry.entity_id)
+        attrs = state_obj.attributes if state_obj else {}
         last = attrs.get("last_triggered")
+        name = (
+            entry.name
+            or entry.original_name
+            or attrs.get("friendly_name")
+            or entry.entity_id
+        )
         scripts.append(
             ScriptSnapshot(
-                entity_id=state.entity_id,
-                name=attrs.get("friendly_name") or state.entity_id,
+                entity_id=entry.entity_id,
+                name=name,
                 description=attrs.get("description") or None,
-                state=state.state,
+                state=state_obj.state if state_obj else "disabled",
                 last_triggered=last.isoformat() if hasattr(last, "isoformat") else last,
-                area_id=_entity_area(entity_reg, state.entity_id),
+                area_id=entry.area_id,
             ),
         )
     scripts.sort(key=lambda s: (s.name.lower(), s.entity_id))
@@ -448,13 +472,23 @@ def _extract_scenes(
     entity_reg: er.EntityRegistry,
 ) -> list[SceneSnapshot]:
     scenes: list[SceneSnapshot] = []
-    for state in hass.states.async_all("scene"):
-        attrs = state.attributes
+    # See _extract_automations: entity-registry walk (issue #39).
+    for entry in entity_reg.entities.values():
+        if not entry.entity_id.startswith("scene."):
+            continue
+        state_obj = hass.states.get(entry.entity_id)
+        attrs = state_obj.attributes if state_obj else {}
+        name = (
+            entry.name
+            or entry.original_name
+            or attrs.get("friendly_name")
+            or entry.entity_id
+        )
         scenes.append(
             SceneSnapshot(
-                entity_id=state.entity_id,
-                name=attrs.get("friendly_name") or state.entity_id,
-                area_id=_entity_area(entity_reg, state.entity_id),
+                entity_id=entry.entity_id,
+                name=name,
+                area_id=entry.area_id,
             ),
         )
     scenes.sort(key=lambda s: (s.name.lower(), s.entity_id))

--- a/custom_components/bookstack_sync/manifest.json
+++ b/custom_components/bookstack_sync/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dibi73/ha-bookstack-sync/issues",
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.8.1"
+  "version": "0.8.2"
 }

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -401,3 +401,30 @@ async def test_router_prefers_private_ip_over_wan(hass: HomeAssistant) -> None:
     # Extra contains the WAN IP.
     assert len(udm.network_extra) == 1
     assert udm.network_extra[0].ip == "85.20.30.40"
+
+
+async def test_disabled_automation_still_extracted(hass: HomeAssistant) -> None:
+    """Regression for #39: an automation with no state object still appears.
+
+    Previously the extractor used hass.states.async_all('automation') which
+    returns 0 results when entities exist in the registry but their states
+    aren't yet hydrated (early-startup race) or when the user has disabled
+    automations. The fix walks the entity registry instead.
+    """
+    entity_reg = er.async_get(hass)
+    entry = entity_reg.async_get_or_create(
+        domain="automation",
+        platform="automation",
+        unique_id="never_started",
+        suggested_object_id="never_started",
+    )
+    # Crucially: do NOT set hass.states for this entity. It exists only
+    # in the registry (e.g. disabled, or hydration not yet done).
+
+    snap = extract_snapshot(hass)
+    names = [a.name for a in snap.automations]
+    assert entry.entity_id in names or any(
+        a.entity_id == entry.entity_id for a in snap.automations
+    )
+    found = next(a for a in snap.automations if a.entity_id == entry.entity_id)
+    assert found.state == "disabled"


### PR DESCRIPTION
Closes #39.

## Bug
Bundle-Pages *Automatisierungen* / *Skripte* / *Szenen* renderten als leer (\"Automatisierungen (0)\") obwohl der User Automatisierungen in HA hat.

## Root cause
\`hass.states.async_all(<domain>)\` returnt nichts für deaktivierte Automatisierungen oder wenn der State noch nicht hydriert ist (Race-Condition früh nach HA-Start / -Reload).

## Fix
Extraktion läuft jetzt über die **entity_registry** als Source-of-Truth, State-Object wird optional dazugeholt. Deaktivierte Einträge bekommen ``state=\"disabled\"\`\`.

Gilt für \`_extract_automations\` / \`_extract_scripts\` / \`_extract_scenes\`.

## Test
Regression-Test \`test_disabled_automation_still_extracted\`: Automation nur in entity_registry, kein State → muss trotzdem im Snapshot auftauchen.

## Test plan
- [ ] CI grün
- [ ] Manual: Sync auslösen → Bundle-Page *Automatisierungen* zeigt jetzt alle Einträge