### PR TITLE
V0.10.1: fix Übersicht-page links (BookStack {{@id}} cross-link syntax)

### DIFF
--- a/custom_components/bookstack_sync/manifest.json
+++ b/custom_components/bookstack_sync/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dibi73/ha-bookstack-sync/issues",
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.10.0"
+  "version": "0.10.1"
 }

--- a/custom_components/bookstack_sync/renderer.py
+++ b/custom_components/bookstack_sync/renderer.py
@@ -171,7 +171,12 @@ def render_overview_auto_block(
     for key, label in bundle_links:
         page_id = links.get(key)
         if page_id is not None:
-            lines.append(f"- [{label}](page:{page_id})")
+            # BookStack expands ``{{@<id>}}`` server-side into a clickable
+            # link to the page with that id (rendered with the actual
+            # page title). Plain markdown ``[label](page:id)`` doesn't
+            # work — BookStack treats ``page:id`` as a relative URL and
+            # 404s on click.
+            lines.append(f"- {{{{@{page_id}}}}}")
         else:
             lines.append(f"- {label}")
 
@@ -180,9 +185,7 @@ def render_overview_auto_block(
         for area in snapshot.areas:
             label = _md_escape(area.name)
             page_id = links.get(f"area:{area.area_id}")
-            link = (
-                f"[{label}](page:{page_id})" if page_id is not None else f"**{label}**"
-            )
+            link = f"{{{{@{page_id}}}}}" if page_id is not None else f"**{label}**"
             lines.append(
                 f"- {link} – {len(area.devices)} {strings['stat_devices']}",
             )
@@ -200,7 +203,7 @@ def render_overview_auto_block(
         for device in snapshot.unassigned_devices:
             label = _md_escape(device.name)
             page_id = links.get(f"device:{device.device_id}")
-            link = f"[{label}](page:{page_id})" if page_id is not None else label
+            link = f"{{{{@{page_id}}}}}" if page_id is not None else label
             lines.append(f"- {link}")
 
     return "\n".join(lines)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -348,20 +348,19 @@ class TestOverviewLinks:
                 f"legacy [label](page:N) syntax found in output: {out[:200]!r}"
             )
 
-    def test_special_chars_in_area_name_escaped(
+    def test_special_chars_in_area_name_escaped_when_no_link(
         self,
         fixed_now: datetime,
         strings_de: dict[str, str],
     ) -> None:
+        # When a page-link IS available, BookStack's ``{{@id}}`` expands
+        # to the page title server-side — our custom label is dropped.
+        # When NO page-link exists we fall back to ``**escaped_label**``
+        # — and that path must still escape special chars.
         area = AreaSnapshot(area_id="living", name="Wohn|zimmer <stage>")
         snap = _empty_snapshot()
         snap.areas.append(area)
-        out = render_overview_auto_block(
-            snap,
-            fixed_now,
-            strings_de,
-            page_links={"area:living": 99},
-        )
+        out = render_overview_auto_block(snap, fixed_now, strings_de)  # no links
         assert r"Wohn\|zimmer &lt;stage&gt;" in out
 
 

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -262,7 +262,8 @@ class TestOverviewLinks:
             strings_de,
             page_links={"area:living": 42},
         )
-        assert "[Living Room](page:42)" in out
+        # BookStack-internal cross-link syntax — server expands {{@N}}.
+        assert "{{@42}}" in out
 
     def test_area_falls_back_to_bold_when_no_link(
         self,
@@ -274,7 +275,7 @@ class TestOverviewLinks:
         snap.areas.append(area)
         out = render_overview_auto_block(snap, fixed_now, strings_de)
         assert "**Living Room**" in out
-        assert "page:" not in out
+        assert "{{@" not in out
 
     def test_bundle_links_rendered(
         self,
@@ -294,11 +295,58 @@ class TestOverviewLinks:
                 "addons:_": 5,
             },
         )
-        assert "[Integrations](page:1)" in out
-        assert "[Automations](page:2)" in out
-        assert "[Scripts](page:3)" in out
-        assert "[Scenes](page:4)" in out
-        assert "[Add-ons](page:5)" in out
+        assert "{{@1}}" in out
+        assert "{{@2}}" in out
+        assert "{{@3}}" in out
+        assert "{{@4}}" in out
+        assert "{{@5}}" in out
+
+    def test_no_legacy_page_link_syntax_anywhere(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
+        """
+        Regression #55: never emit ``](page:`` anywhere in any rendered page.
+
+        The naïve markdown link form ``[label](page:42)`` is treated by
+        BookStack as a relative URL ``page:42`` and 404s on click. The
+        correct format is the BookStack server-side template
+        ``{{@42}}``. This test calls every ``render_*_auto_block`` we
+        ship and asserts the bad pattern never appears.
+        """
+        # Exercise a snapshot with all the page-link entry-points populated.
+        area = AreaSnapshot(area_id="living", name="Wohnzimmer")
+        snap = _empty_snapshot()
+        snap.areas.append(area)
+        snap.unassigned_devices.append(_device(name="Some Unassigned Device"))
+
+        outputs: list[str] = [
+            render_overview_auto_block(
+                snap,
+                fixed_now,
+                strings_de,
+                page_links={
+                    "integrations:_": 1,
+                    "automations:_": 2,
+                    "scripts:_": 3,
+                    "scenes:_": 4,
+                    "addons:_": 5,
+                    "area:living": 99,
+                    "device:dev1": 100,
+                },
+            ),
+            render_area_auto_block(area, fixed_now, strings_de),
+            render_device_auto_block(
+                _device(name="Plain Device"),
+                fixed_now,
+                strings_de,
+            ),
+        ]
+        for out in outputs:
+            assert "](page:" not in out, (
+                f"legacy [label](page:N) syntax found in output: {out[:200]!r}"
+            )
 
     def test_special_chars_in_area_name_escaped(
         self,


### PR DESCRIPTION
Closes #55.

## Bug

Auf der *Übersicht*-Seite waren die Links auf andere Pages kaputt. Wir generierten ``[Geräte](page:42)`` — was BookStack als relative URL ``page:42`` interpretiert und beim Klick 404'd. Das ``page:N``-URL-Schema war nie ein echtes BookStack-Feature, ich hatte das angenommen.

## Fix

Switch auf BookStack's eigene **Cross-Link-Notation** in Markdown: ``{{@<page_id>}}``. BookStack expandiert das server-seitig zu einem klickbaren Link auf die Page mit der entsprechenden ID. Label kommt automatisch vom Page-Titel.

Drei Stellen in ``render_overview_auto_block`` umgestellt:
- Bundle-Links (Integrationen / Automatisierungen / ...)
- Area-Links (Räume in der Liste)
- Unassigned-Devices-Links

## Trade-off
- ✅ Funktioniert ohne base_url / book_slug / page_slug zu kennen
- ⚠️ Custom-Label geht verloren (BookStack nutzt automatisch Page-Titel) — in der Praxis matcht das eh meist

## Regression-Schutz

Neuer Test ``test_no_legacy_page_link_syntax_anywhere`` ruft Overview / Area / Device Renderer mit allen page_link-Einträgen auf und failed wenn jemals wieder ``](page:`` im Output landet. Plus die bestehenden bundle/area/device-Link-Tests checken explizit auf ``{{@N}}``.

## Test plan
- [ ] CI: ruff + pytest grün
- [ ] Manual: nach Sync Übersicht-Page öffnen, auf einen Link klicken → muss zur Ziel-Page führen, kein 404