### PR TITLE
V0.11.0: Sync-Button + Tampering-False-Positive-Fix

### DIFF
--- a/custom_components/bookstack_sync/__init__.py
+++ b/custom_components/bookstack_sync/__init__.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
     from .data import BookStackSyncConfigEntry
 
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BUTTON]
 
 
 async def async_setup_entry(

--- a/custom_components/bookstack_sync/button.py
+++ b/custom_components/bookstack_sync/button.py
@@ -1,0 +1,121 @@
+"""
+Button entities for BookStack Sync (issue #57).
+
+Two buttons land on the integration's device card:
+
+- ``Jetzt synchronisieren`` — fires ``coordinator.async_run_sync(dry_run=False)``
+- ``Sync-Vorschau``        — fires ``coordinator.async_run_sync(dry_run=True)``
+
+These mirror the ``bookstack_sync.run_now`` / ``bookstack_sync.preview``
+services but show up directly on the device card so the user doesn't
+have to walk through Developer Tools to trigger a sync.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from .coordinator import BookStackSyncCoordinator
+    from .data import BookStackSyncConfigEntry
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,  # noqa: ARG001 - HA contract
+    entry: BookStackSyncConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Register the run-now and preview buttons for this entry."""
+    coordinator = entry.runtime_data.coordinator
+    async_add_entities(
+        [
+            BookStackSyncRunNowButton(coordinator),
+            BookStackSyncPreviewButton(coordinator),
+        ],
+    )
+
+
+class _BookStackSyncButtonBase(CoordinatorEntity, ButtonEntity):
+    """
+    Base class for BookStack-Sync buttons.
+
+    Both buttons share the device-info, entity-category and
+    coordinator-disabled-while-running gating.
+    """
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: BookStackSyncCoordinator,
+        translation_key: str,
+        unique_suffix: str,
+        icon: str,
+    ) -> None:
+        """Bind to the coordinator and seed identifiers."""
+        super().__init__(coordinator)
+        entry_id = coordinator.config_entry.entry_id
+        self._attr_unique_id = f"{entry_id}_{unique_suffix}"
+        self._attr_translation_key = translation_key
+        self._attr_icon = icon
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry_id)},
+            name=coordinator.config_entry.title,
+            manufacturer="BookStack Sync",
+            entry_type=None,
+        )
+
+    @property
+    def available(self) -> bool:
+        """
+        Disable the button while a sync is in flight.
+
+        Pressing during an active run would just queue behind the
+        coordinator's lock, but greying it out is friendlier UX.
+        """
+        return not self.coordinator.is_syncing
+
+
+class BookStackSyncRunNowButton(_BookStackSyncButtonBase):
+    """Pressing this button kicks off a real sync immediately."""
+
+    def __init__(self, coordinator: BookStackSyncCoordinator) -> None:
+        """Wire the run-now button to the coordinator."""
+        super().__init__(
+            coordinator,
+            translation_key="run_now",
+            unique_suffix="run_now",
+            icon="mdi:cloud-upload",
+        )
+
+    async def async_press(self) -> None:
+        """Trigger an immediate full sync."""
+        await self.coordinator.async_run_sync(dry_run=False)
+
+
+class BookStackSyncPreviewButton(_BookStackSyncButtonBase):
+    """Pressing this button performs a dry-run sync (logs only)."""
+
+    def __init__(self, coordinator: BookStackSyncCoordinator) -> None:
+        """Wire the preview button to the coordinator."""
+        super().__init__(
+            coordinator,
+            translation_key="preview",
+            unique_suffix="preview",
+            icon="mdi:cloud-search",
+        )
+
+    async def async_press(self) -> None:
+        """Trigger a dry-run sync — logs to HA log, writes nothing."""
+        await self.coordinator.async_run_sync(dry_run=True)

--- a/custom_components/bookstack_sync/manifest.json
+++ b/custom_components/bookstack_sync/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dibi73/ha-bookstack-sync/issues",
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.10.1"
+  "version": "0.11.0"
 }

--- a/custom_components/bookstack_sync/store.py
+++ b/custom_components/bookstack_sync/store.py
@@ -15,12 +15,27 @@ if TYPE_CHECKING:
 
 @dataclass
 class PageMapping:
-    """Tracks one synced page so we can update instead of duplicate."""
+    """
+    Tracks one synced page so we can update instead of duplicate.
+
+    ``hash_origin`` (issue #58) is ``"write"`` for hashes computed from
+    what we sent to BookStack and ``"bookstack"`` for hashes computed
+    from what BookStack returned in the create/update response. Round-
+    trip hashes survive BookStack's markdown normalisation; write-side
+    hashes can drift when BookStack normalises whitespace / line endings
+    / Unicode and produce false-positive tampering reports.
+
+    Migration: existing entries default to ``"write"``. The next sync
+    suppresses tampering detection on these and stores a
+    ``"bookstack"``-origin hash, settling the mapping into the new
+    regime within one sync cycle.
+    """
 
     page_id: int
     auto_block_hash: str = ""
     last_seen: str | None = None  # ISO timestamp of last successful sync
     tombstoned_at: str | None = None  # ISO timestamp; set when soft-deleted
+    hash_origin: str = "write"  # "write" (legacy) or "bookstack" (round-trip)
 
 
 @dataclass
@@ -57,8 +72,15 @@ class BookStackSyncStore:
         raw = await self._store.async_load() or {}
         pages_raw = raw.get("pages", {}) or {}
         chapters_raw = raw.get("chapters", {}) or {}
+        # Migration: pre-v0.11 storage doesn't have ``hash_origin``.
+        # Drop unknown fields gracefully (forward-compat too).
+        known_fields = set(PageMapping.__dataclass_fields__)
+        pages: dict[str, PageMapping] = {}
+        for key, value in pages_raw.items():
+            filtered = {k: v for k, v in value.items() if k in known_fields}
+            pages[key] = PageMapping(**filtered)
         self._state = StoredState(
-            pages={key: PageMapping(**value) for key, value in pages_raw.items()},
+            pages=pages,
             chapters={key: int(value) for key, value in chapters_raw.items()},
         )
         self._loaded = True

--- a/custom_components/bookstack_sync/strings.json
+++ b/custom_components/bookstack_sync/strings.json
@@ -103,6 +103,14 @@
           "syncing": "Sync läuft"
         }
       }
+    },
+    "button": {
+      "run_now": {
+        "name": "Jetzt synchronisieren"
+      },
+      "preview": {
+        "name": "Sync-Vorschau (Dry-Run)"
+      }
     }
   },
   "issues": {

--- a/custom_components/bookstack_sync/sync.py
+++ b/custom_components/bookstack_sync/sync.py
@@ -87,6 +87,29 @@ def _orphaned_tags() -> list[dict[str, str]]:
     return [{"name": TAG_NAME, "value": TAG_VALUE_ORPHANED}]
 
 
+def _hash_from_response(
+    response: dict,
+    fallback_auto_body: str,
+) -> tuple[str, str]:
+    """
+    Return (hash, origin) for a create/update response.
+
+    BookStack normalises the markdown when saving (whitespace, line
+    endings). If we hash what we *sent*, the next read produces a
+    different hash and we mistakenly flag it as tampered (issue #58).
+    Solution: hash what BookStack actually stored — extract the AUTO
+    block from the response's ``markdown`` field. If that field is
+    missing (older BookStack), fall back to write-side hash and mark
+    origin so the migration path takes over on the next sync.
+    """
+    saved_markdown = response.get("markdown") or ""
+    if saved_markdown:
+        saved_auto = extract_auto_block(saved_markdown)
+        if saved_auto is not None:
+            return hash_auto_block(saved_auto), "bookstack"
+    return hash_auto_block(fallback_auto_body), "write"
+
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
@@ -543,12 +566,15 @@ async def _sync_one(  # noqa: PLR0913 - cohesive sync step, splitting hurts clar
                 tags=_managed_tags(),
             )
         page_id = int(created["id"])
+        # Hash what BookStack actually stored, not what we sent (#58).
+        saved_hash, hash_origin = _hash_from_response(created, page.auto_body)
         store.set(
             page.key,
             PageMapping(
                 page_id=page_id,
-                auto_block_hash=new_hash,
+                auto_block_hash=saved_hash,
                 last_seen=datetime.now(tz=UTC).isoformat(),
+                hash_origin=hash_origin,
             ),
         )
         report.created.append(page.title)
@@ -569,18 +595,39 @@ async def _sync_one(  # noqa: PLR0913 - cohesive sync step, splitting hurts clar
     )
 
     if merged.manual_block_tampered:
-        LOGGER.warning(
-            "BookStack page %s (id=%s): AUTO block was edited outside of "
-            "Home Assistant - skipping to avoid clobbering manual changes.",
-            page.title,
-            mapping.page_id,
-        )
-        report.skipped_conflict.append(page.title)
-        report.tampered_page_keys.append(page.key)
-        report.tampered_page_titles.append(page.title)
-        return mapping.page_id
+        if mapping.hash_origin != "bookstack":
+            # Migration path (#58): legacy ``write``-origin hashes can't
+            # reliably detect tampering against BookStack's normalised
+            # storage. Trust the user, fall through to a fresh write
+            # which will store a correct ``bookstack``-origin hash.
+            LOGGER.info(
+                "BookStack page %s (id=%s): write-origin hash from "
+                "pre-v0.11 — suppressing tampering check on this run, "
+                "migrating to bookstack-origin hash.",
+                page.title,
+                mapping.page_id,
+            )
+        else:
+            LOGGER.warning(
+                "BookStack page %s (id=%s): AUTO block was edited outside "
+                "of Home Assistant - skipping to avoid clobbering manual "
+                "changes.",
+                page.title,
+                mapping.page_id,
+            )
+            report.skipped_conflict.append(page.title)
+            report.tampered_page_keys.append(page.key)
+            report.tampered_page_titles.append(page.title)
+            return mapping.page_id
 
-    if existing_auto_hash == new_hash and not needs_move:
+    if (
+        existing_auto_hash == new_hash
+        and not needs_move
+        and mapping.hash_origin == "bookstack"
+    ):
+        # Skip-on-unchanged needs a trustworthy stored hash — only
+        # safe when origin is ``bookstack``. Legacy ``write`` mappings
+        # always re-write once to settle into the new regime.
         report.unchanged.append(page.title)
         mapping.last_seen = datetime.now(tz=UTC).isoformat()
         store.set(page.key, mapping)
@@ -590,20 +637,22 @@ async def _sync_one(  # noqa: PLR0913 - cohesive sync step, splitting hurts clar
         report.updated.append(page.title)
         return mapping.page_id
 
-    await client.update_page(
+    saved = await client.update_page(
         mapping.page_id,
         page.title,
         merged.body,
         chapter_id=chapter_id if needs_move else None,
         tags=_managed_tags(),
     )
+    saved_hash, hash_origin = _hash_from_response(saved, page.auto_body)
     store.set(
         page.key,
         PageMapping(
             page_id=mapping.page_id,
-            auto_block_hash=merged.auto_hash,
+            auto_block_hash=saved_hash,
             last_seen=datetime.now(tz=UTC).isoformat(),
             tombstoned_at=None,  # device is back; clear any prior tombstone
+            hash_origin=hash_origin,
         ),
     )
     report.updated.append(page.title)
@@ -694,7 +743,6 @@ async def _tombstone_one(  # noqa: PLR0913 - cohesive sync step
     dry_run: bool,
 ) -> None:
     auto_body = render_tombstone_auto_block(strings, now)
-    new_hash = hash_auto_block(auto_body)
 
     existing = await client.get_page(mapping.page_id)
     existing_markdown = existing.get("markdown") or existing.get("raw_html") or ""
@@ -707,14 +755,23 @@ async def _tombstone_one(  # noqa: PLR0913 - cohesive sync step
     )
 
     if merged.manual_block_tampered:
-        LOGGER.warning(
-            "BookStack page id=%s (%s): AUTO block was edited manually - "
-            "skipping tombstone to preserve manual changes.",
-            mapping.page_id,
-            key,
-        )
-        report.skipped_conflict.append(f"{key} (tombstone)")
-        return
+        if mapping.hash_origin != "bookstack":
+            # Migration path (#58): legacy write-origin hash, suppress.
+            LOGGER.info(
+                "BookStack page id=%s (%s): write-origin hash, "
+                "tombstoning anyway (migration to bookstack-origin).",
+                mapping.page_id,
+                key,
+            )
+        else:
+            LOGGER.warning(
+                "BookStack page id=%s (%s): AUTO block was edited manually "
+                "- skipping tombstone to preserve manual changes.",
+                mapping.page_id,
+                key,
+            )
+            report.skipped_conflict.append(f"{key} (tombstone)")
+            return
 
     existing_name = existing.get("name") or key
 
@@ -722,19 +779,21 @@ async def _tombstone_one(  # noqa: PLR0913 - cohesive sync step
         report.tombstoned.append(existing_name)
         return
 
-    await client.update_page(
+    saved = await client.update_page(
         mapping.page_id,
         existing_name,
         merged.body,
         tags=_orphaned_tags(),
     )
+    saved_hash, hash_origin = _hash_from_response(saved, auto_body)
     store.set(
         key,
         PageMapping(
             page_id=mapping.page_id,
-            auto_block_hash=new_hash,
+            auto_block_hash=saved_hash,
             last_seen=mapping.last_seen,
             tombstoned_at=now.isoformat(),
+            hash_origin=hash_origin,
         ),
     )
     report.tombstoned.append(existing_name)

--- a/custom_components/bookstack_sync/translations/de.json
+++ b/custom_components/bookstack_sync/translations/de.json
@@ -103,6 +103,14 @@
           "syncing": "Sync läuft"
         }
       }
+    },
+    "button": {
+      "run_now": {
+        "name": "Jetzt synchronisieren"
+      },
+      "preview": {
+        "name": "Sync-Vorschau (Dry-Run)"
+      }
     }
   },
   "issues": {

--- a/custom_components/bookstack_sync/translations/en.json
+++ b/custom_components/bookstack_sync/translations/en.json
@@ -103,6 +103,14 @@
           "syncing": "Sync running"
         }
       }
+    },
+    "button": {
+      "run_now": {
+        "name": "Sync now"
+      },
+      "preview": {
+        "name": "Sync preview (dry-run)"
+      }
     }
   },
   "issues": {


### PR DESCRIPTION
Closes #57, #58.

## #57 — Sync-Button auf der Integration-Card

Neue Button-Entities ``Jetzt synchronisieren`` + ``Sync-Vorschau (Dry-Run)``. Direkt auf der Integration-Device-Card klickbar — kein Umweg mehr über *Developer Tools → Actions*. Beide gehen ausgegraut während ein Sync läuft.

## #58 — Tampering-False-Positive (kritisch)

User hatte gestern **298 falsche Repair-Issues** ``AUTO-Block einer Page wurde manuell editiert`` ohne wirklich was editiert zu haben.

**Ursache:** BookStack normalisiert beim Speichern den Markdown (Whitespace / Line-Endings). Wir hashen aber was wir *senden*, nicht was BookStack *speichert* — beim Read-Back hashen wir den (normalisierten) Content und kriegen einen anderen Hash → falsch-positiv.

**Fix:** nach jedem ``create_page`` / ``update_page`` extrahieren wir den AUTO-Block aus dem Response (BookStack returnt das gespeicherte ``markdown``-Feld) und hashen **das**. Der Hash spiegelt jetzt was BookStack tatsächlich gespeichert hat.

**Migration:** existierende Storage-Einträge haben das alte ``write``-Origin-Hash-Format. Beim ersten v0.11-Sync wird die Tampering-Erkennung für diese Einträge **suppressed**, fresh content wird geschrieben, neuer ``bookstack``-origin Hash gespeichert. Nach einem vollen Sync-Zyklus ist alles auf der neuen Regime.

User-Workaround vor v0.11 (nicht mehr nötig nach Merge): Repair-Issues ignorieren oder ``.storage/bookstack_sync.{entry_id}.mapping`` löschen.

## Test plan
- [ ] CI: ruff + pytest grün
- [ ] Manual: nach Sync auf der Integration-Card erscheinen 2 Buttons → klicken triggert Sync sofort
- [ ] Manual: alte Setups die heute 298 Tampering-Issues sehen — nach Update auf v0.11 + 1 vollem Sync sollten die Repair-Issues alle auto-resolven (weil die echten Tampering-Erkennungen jetzt korrekt sind und nichts wirklich tampert)
- [ ] Manual: Button greying während aktivem Sync

## Bug-Fix nebenher

Der Python-2-``except``-Syntax-Bug ist *wieder* dabei. Der Parse-Regression-Test aus v0.10.0 fängt ihn jetzt in CI vor dem Merge ab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)