### PR TITLE
V0.12.0: localize UI to 26 additional languages (EU + zh-Hans/nb/uk/th)

### DIFF
--- a/custom_components/bookstack_sync/manifest.json
+++ b/custom_components/bookstack_sync/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dibi73/ha-bookstack-sync/issues",
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.11.0"
+  "version": "0.12.0"
 }

--- a/custom_components/bookstack_sync/translations/bg.json
+++ b/custom_components/bookstack_sync/translations/bg.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "BookStack връзка",
+        "description": "Свържете Home Assistant с вашата BookStack инстанция.\n\nВ BookStack отидете на *Моят акаунт → API токени*, създайте токен и поставете идентификатора и секрета тук.\n\nДокументация: {documentation_url}",
+        "data": {
+          "base_url": "BookStack URL",
+          "token_id": "API токен идентификатор",
+          "token_secret": "API токен секрет",
+          "verify_ssl": "Проверка на TLS сертификат (изключете за самоподписани)"
+        }
+      },
+      "book": {
+        "title": "Изберете целева книга",
+        "description": "В коя книга трябва Home Assistant да синхронизира? Ръчно добавеното съдържание в страниците ще бъде запазено.",
+        "data": {
+          "book_id": "Целева книга",
+          "sync_interval": "Интервал на синхронизация"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Опресняване на BookStack токен",
+        "description": "BookStack отхвърли API токена за {base_url}. Създайте нов токен в BookStack и поставете идентификатора и секрета тук — URL адресът и целевата книга остават същите.",
+        "data": {
+          "token_id": "API токен идентификатор",
+          "token_secret": "API токен секрет"
+        }
+      },
+      "reconfigure": {
+        "title": "Промяна на BookStack връзката",
+        "description": "Променете URL, токен или TLS настройка на тази BookStack връзка. Целевата книга и всички съответствия на страници се запазват. URL адресът трябва да сочи към същата BookStack инстанция както преди.",
+        "data": {
+          "base_url": "BookStack URL",
+          "token_id": "API токен идентификатор",
+          "token_secret": "API токен секрет",
+          "verify_ssl": "Проверка на TLS сертификат (изключете за самоподписани)"
+        }
+      }
+    },
+    "error": {
+      "auth": "API токенът е отхвърлен или липсват разрешения.",
+      "connection": "Не може да се достигне до BookStack.",
+      "no_books": "В тази BookStack инстанция не е намерена книга. Създайте първо целева книга.",
+      "unknown": "Неочаквана грешка — проверете Home Assistant журнала.",
+      "base_url_invalid_scheme": "URL трябва да започва с http:// или https://.",
+      "base_url_missing_host": "URL е непълен — липсва име на хост."
+    },
+    "abort": {
+      "already_configured": "Тази BookStack инстанция вече е конфигурирана.",
+      "reauth_successful": "Токенът е опреснен — BookStack връзката е възстановена.",
+      "reconfigure_successful": "Връзката е актуализирана — BookStack Sync е преконфигуриран.",
+      "url_mismatch": "Новият URL сочи към различна BookStack инстанция. Моля, премахнете оригиналния запис и добавете нов."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Настройки на BookStack Sync",
+        "data": {
+          "book_id": "Целева книга",
+          "sync_interval": "Интервал на синхронизация",
+          "excluded_areas": "Изключени зони (няма да бъдат синхронизирани)",
+          "output_language": "Език на BookStack страниците"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "На час",
+        "daily": "Ежедневно",
+        "manual": "Само ръчно (повикване на услуга)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Като Home Assistant (авто)",
+        "de": "Немски",
+        "en": "Английски"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Синхронизирай сега",
+      "description": "Стартира синхронизация веднага, без да чака интервала."
+    },
+    "preview": {
+      "name": "Преглед на синхронизация",
+      "description": "Записва в журнала кои страници ще бъдат създадени/актуализирани, без да пише нищо в BookStack."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Състояние на синхронизация",
+        "state": {
+          "ok": "OK",
+          "error": "Грешка",
+          "never_run": "Никога не е стартиран",
+          "syncing": "Синхронизация в ход"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Синхронизирай сега"
+      },
+      "preview": {
+        "name": "Преглед на синхронизация (пробно)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack е недостъпен",
+      "description": "BookStack Sync интеграцията не може да достигне до BookStack инстанцията в продължение на {count} последователни синхронизации. Чести причини: BookStack контейнерът е спрян, мрежов проблем или обратен прокси отхвърля връзките. Следващата успешна синхронизация автоматично разрешава това известие."
+    },
+    "page_tampered": {
+      "title": "AUTO блокът на страница е редактиран ръчно",
+      "description": "Страницата „{page_title}\" в BookStack има AUTO блок, който е редактиран извън Home Assistant. Интеграцията пропусна тази страница, за да не презапише вашите промени. Преместете бележките си в MANUAL блока или отменете промяната в AUTO блока, за да може следващата синхронизация да актуализира страницата отново."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "BookStack инстанцията е недостъпна (вижте Home Assistant журнала за подробности)."
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack отхвърли API токена. Опреснете токена в BookStack и използвайте Reauth потока."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/cs.json
+++ b/custom_components/bookstack_sync/translations/cs.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Připojení k BookStack",
+        "description": "Připojte Home Assistant ke své instanci BookStack.\n\nV BookStack přejděte do *Můj účet → API tokeny*, vytvořte token a vložte ID a tajný klíč zde.\n\nDokumentace: {documentation_url}",
+        "data": {
+          "base_url": "BookStack URL",
+          "token_id": "ID API tokenu",
+          "token_secret": "Tajný klíč API tokenu",
+          "verify_ssl": "Ověřit TLS certifikát (vypněte pro vlastnoručně podepsané)"
+        }
+      },
+      "book": {
+        "title": "Vyberte cílovou knihu",
+        "description": "Do které knihy má Home Assistant synchronizovat? Ručně přidaný obsah ve stránkách bude zachován.",
+        "data": {
+          "book_id": "Cílová kniha",
+          "sync_interval": "Interval synchronizace"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Obnovit BookStack token",
+        "description": "BookStack odmítl API token pro {base_url}. Vytvořte v BookStack nový token a vložte ID a tajný klíč zde — URL a cílová kniha zůstávají stejné.",
+        "data": {
+          "token_id": "ID API tokenu",
+          "token_secret": "Tajný klíč API tokenu"
+        }
+      },
+      "reconfigure": {
+        "title": "Upravit připojení k BookStack",
+        "description": "Změňte URL, token nebo nastavení TLS pro toto připojení. Cílová kniha a všechna mapování stránek zůstanou zachována. URL musí ukazovat na stejnou instanci BookStack jako dříve.",
+        "data": {
+          "base_url": "BookStack URL",
+          "token_id": "ID API tokenu",
+          "token_secret": "Tajný klíč API tokenu",
+          "verify_ssl": "Ověřit TLS certifikát (vypněte pro vlastnoručně podepsané)"
+        }
+      }
+    },
+    "error": {
+      "auth": "API token byl odmítnut nebo chybí oprávnění.",
+      "connection": "Nelze se připojit k BookStack.",
+      "no_books": "V této instanci BookStack nebyla nalezena žádná kniha. Vytvořte nejprve cílovou knihu.",
+      "unknown": "Neočekávaná chyba — zkontrolujte protokol Home Assistant.",
+      "base_url_invalid_scheme": "URL musí začínat http:// nebo https://.",
+      "base_url_missing_host": "URL je neúplná — chybí název hostitele."
+    },
+    "abort": {
+      "already_configured": "Tato instance BookStack je již nakonfigurována.",
+      "reauth_successful": "Token obnoven — připojení k BookStack obnoveno.",
+      "reconfigure_successful": "Připojení aktualizováno — BookStack Sync byl překonfigurován.",
+      "url_mismatch": "Nová URL ukazuje na jinou instanci BookStack. Odstraňte prosím původní záznam a přidejte nový."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Nastavení BookStack Sync",
+        "data": {
+          "book_id": "Cílová kniha",
+          "sync_interval": "Interval synchronizace",
+          "excluded_areas": "Vyloučené oblasti (nebudou synchronizovány)",
+          "output_language": "Jazyk stránek BookStack"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "Každou hodinu",
+        "daily": "Denně",
+        "manual": "Pouze ručně (volání služby)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Jako Home Assistant (auto)",
+        "de": "Němčina",
+        "en": "Angličtina"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Synchronizovat nyní",
+      "description": "Spustí synchronizaci okamžitě, bez čekání na interval."
+    },
+    "preview": {
+      "name": "Náhled synchronizace",
+      "description": "Zaznamená do protokolu, které stránky by byly vytvořeny/aktualizovány, ale do BookStack nic nezapisuje."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Stav synchronizace",
+        "state": {
+          "ok": "OK",
+          "error": "Chyba",
+          "never_run": "Dosud nespuštěno",
+          "syncing": "Synchronizace probíhá"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Synchronizovat nyní"
+      },
+      "preview": {
+        "name": "Náhled synchronizace (zkušební)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack je nedostupný",
+      "description": "Integrace BookStack Sync nemohla dosáhnout instance BookStack po {count} po sobě jdoucích synchronizací. Časté příčiny: kontejner BookStack je zastaven, problém se sítí nebo reverzní proxy odmítá spojení. Další úspěšná synchronizace toto upozornění automaticky vyřeší."
+    },
+    "page_tampered": {
+      "title": "AUTO blok stránky byl ručně upraven",
+      "description": "Stránka „{page_title}\" v BookStack má AUTO blok, který byl upraven mimo Home Assistant. Integrace tuto stránku při synchronizaci přeskočila, aby nepřepsala vaše úpravy. Přesuňte své poznámky do bloku MANUAL nebo vraťte změnu v AUTO bloku, aby další synchronizace mohla stránku znovu aktualizovat."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "Instance BookStack je nedostupná (podrobnosti viz protokol Home Assistant)."
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack odmítl API token. Obnovte token v BookStack a použijte Reauth postup."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/da.json
+++ b/custom_components/bookstack_sync/translations/da.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "BookStack-forbindelse",
+        "description": "Forbind Home Assistant til din BookStack-instans.\n\nI BookStack gå til *Min konto → API-tokens*, opret et token, og indsæt ID og hemmelighed her.\n\nDokumentation: {documentation_url}",
+        "data": {
+          "base_url": "BookStack URL",
+          "token_id": "API-token-ID",
+          "token_secret": "API-token-hemmelighed",
+          "verify_ssl": "Verificer TLS-certifikat (deaktiver for selvsignerede)"
+        }
+      },
+      "book": {
+        "title": "Vælg målbog",
+        "description": "Hvilken bog skal Home Assistant synkronisere til? Manuelt tilføjet indhold på siderne bevares.",
+        "data": {
+          "book_id": "Målbog",
+          "sync_interval": "Synkroniseringsinterval"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Forny BookStack-token",
+        "description": "BookStack afviste API-tokenet for {base_url}. Opret et nyt token i BookStack, og indsæt ID og hemmelighed her — URL og målbog forbliver de samme.",
+        "data": {
+          "token_id": "API-token-ID",
+          "token_secret": "API-token-hemmelighed"
+        }
+      },
+      "reconfigure": {
+        "title": "Justér BookStack-forbindelse",
+        "description": "Skift URL, token eller TLS-indstilling for denne BookStack-forbindelse. Målbogen og alle sidetilknytninger bevares. URL'en skal pege på samme BookStack-instans som før.",
+        "data": {
+          "base_url": "BookStack URL",
+          "token_id": "API-token-ID",
+          "token_secret": "API-token-hemmelighed",
+          "verify_ssl": "Verificer TLS-certifikat (deaktiver for selvsignerede)"
+        }
+      }
+    },
+    "error": {
+      "auth": "API-token afvist eller manglende rettigheder.",
+      "connection": "Kan ikke nå BookStack.",
+      "no_books": "Ingen bog fundet i denne BookStack-instans. Opret først en målbog.",
+      "unknown": "Uventet fejl — tjek Home Assistant-loggen.",
+      "base_url_invalid_scheme": "URL'en skal starte med http:// eller https://.",
+      "base_url_missing_host": "URL'en er ufuldstændig — værtsnavn mangler."
+    },
+    "abort": {
+      "already_configured": "Denne BookStack-instans er allerede konfigureret.",
+      "reauth_successful": "Token fornyet — BookStack-forbindelse genoprettet.",
+      "reconfigure_successful": "Forbindelse opdateret — BookStack Sync er blevet omkonfigureret.",
+      "url_mismatch": "Den nye URL peger på en anden BookStack-instans. Fjern den oprindelige post og opret en ny."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "BookStack Sync-indstillinger",
+        "data": {
+          "book_id": "Målbog",
+          "sync_interval": "Synkroniseringsinterval",
+          "excluded_areas": "Ekskluderede områder (synkroniseres ikke)",
+          "output_language": "Sprog for BookStack-sider"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "Hver time",
+        "daily": "Dagligt",
+        "manual": "Kun manuelt (servicekald)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Følg Home Assistant (auto)",
+        "de": "Tysk",
+        "en": "Engelsk"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Synkronisér nu",
+      "description": "Starter en synkronisering med det samme uden at vente på intervallet."
+    },
+    "preview": {
+      "name": "Synkroniseringsforhåndsvisning",
+      "description": "Logger hvilke sider der ville blive oprettet/opdateret uden at skrive noget til BookStack."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Synkroniseringsstatus",
+        "state": {
+          "ok": "OK",
+          "error": "Fejl",
+          "never_run": "Aldrig kørt",
+          "syncing": "Synkronisering kører"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Synkronisér nu"
+      },
+      "preview": {
+        "name": "Synkroniseringsforhåndsvisning (tør-kørsel)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack er ikke tilgængelig",
+      "description": "BookStack Sync-integrationen har ikke kunnet nå BookStack-instansen i {count} på hinanden følgende synkroniseringer. Almindelige årsager: BookStack-containeren er stoppet, et netværksproblem, eller en omvendt proxy afviser forbindelser. Den næste vellykkede synkronisering løser denne notifikation automatisk."
+    },
+    "page_tampered": {
+      "title": "En sides AUTO-blok er blevet redigeret manuelt",
+      "description": "Siden „{page_title}\" i BookStack har en AUTO-blok, der er blevet redigeret uden for Home Assistant. Integrationen sprang denne side over ved synkronisering for ikke at overskrive dine ændringer. Flyt dine noter til MANUAL-blokken, eller fortryd ændringen i AUTO-blokken, så den næste synkronisering kan opdatere siden igen."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "BookStack-instans utilgængelig (se Home Assistant-loggen for detaljer)."
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack afviste API-tokenet. Forny tokenet i BookStack og brug Reauth-flowet."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/el.json
+++ b/custom_components/bookstack_sync/translations/el.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Σύνδεση BookStack",
+        "description": "Συνδέστε το Home Assistant με την εγκατάστασή σας του BookStack.\n\nΣτο BookStack μεταβείτε στο *Ο λογαριασμός μου → API tokens*, δημιουργήστε ένα token και επικολλήστε το ID και το μυστικό εδώ.\n\nΤεκμηρίωση: {documentation_url}",
+        "data": {
+          "base_url": "BookStack URL",
+          "token_id": "API token ID",
+          "token_secret": "API token μυστικό",
+          "verify_ssl": "Επαλήθευση πιστοποιητικού TLS (απενεργοποιήστε για αυτο-υπογεγραμμένα)"
+        }
+      },
+      "book": {
+        "title": "Επιλέξτε βιβλίο προορισμού",
+        "description": "Σε ποιο βιβλίο πρέπει το Home Assistant να συγχρονίσει; Το χειροκίνητα προστιθέμενο περιεχόμενο εντός σελίδων διατηρείται.",
+        "data": {
+          "book_id": "Βιβλίο προορισμού",
+          "sync_interval": "Διάστημα συγχρονισμού"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Ανανέωση BookStack token",
+        "description": "Το BookStack απέρριψε το API token για {base_url}. Δημιουργήστε νέο token στο BookStack και επικολλήστε το ID και το μυστικό εδώ — η διεύθυνση URL και το βιβλίο προορισμού παραμένουν τα ίδια.",
+        "data": {
+          "token_id": "API token ID",
+          "token_secret": "API token μυστικό"
+        }
+      },
+      "reconfigure": {
+        "title": "Προσαρμογή σύνδεσης BookStack",
+        "description": "Αλλάξτε URL, token ή ρύθμιση TLS για αυτή τη σύνδεση. Το βιβλίο προορισμού και όλες οι αντιστοιχίσεις σελίδων διατηρούνται. Η διεύθυνση URL πρέπει να δείχνει στην ίδια εγκατάσταση BookStack όπως πριν.",
+        "data": {
+          "base_url": "BookStack URL",
+          "token_id": "API token ID",
+          "token_secret": "API token μυστικό",
+          "verify_ssl": "Επαλήθευση πιστοποιητικού TLS (απενεργοποιήστε για αυτο-υπογεγραμμένα)"
+        }
+      }
+    },
+    "error": {
+      "auth": "Το API token απορρίφθηκε ή λείπουν δικαιώματα.",
+      "connection": "Δεν είναι δυνατή η πρόσβαση στο BookStack.",
+      "no_books": "Δεν βρέθηκε βιβλίο σε αυτή την εγκατάσταση BookStack. Δημιουργήστε πρώτα ένα βιβλίο προορισμού.",
+      "unknown": "Απρόσμενο σφάλμα — ελέγξτε το αρχείο καταγραφής Home Assistant.",
+      "base_url_invalid_scheme": "Η URL πρέπει να ξεκινά με http:// ή https://.",
+      "base_url_missing_host": "Η URL είναι ελλιπής — λείπει το όνομα κεντρικού υπολογιστή."
+    },
+    "abort": {
+      "already_configured": "Αυτή η εγκατάσταση BookStack είναι ήδη ρυθμισμένη.",
+      "reauth_successful": "Token ανανεώθηκε — η σύνδεση BookStack αποκαταστάθηκε.",
+      "reconfigure_successful": "Η σύνδεση ενημερώθηκε — το BookStack Sync αναδιαμορφώθηκε.",
+      "url_mismatch": "Η νέα URL δείχνει σε διαφορετική εγκατάσταση BookStack. Αφαιρέστε την αρχική καταχώρηση και προσθέστε μια νέα."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Ρυθμίσεις BookStack Sync",
+        "data": {
+          "book_id": "Βιβλίο προορισμού",
+          "sync_interval": "Διάστημα συγχρονισμού",
+          "excluded_areas": "Εξαιρούμενες περιοχές (δεν θα συγχρονιστούν)",
+          "output_language": "Γλώσσα των σελίδων BookStack"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "Ωριαία",
+        "daily": "Καθημερινά",
+        "manual": "Μόνο χειροκίνητα (κλήση υπηρεσίας)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Όπως το Home Assistant (αυτόματα)",
+        "de": "Γερμανικά",
+        "en": "Αγγλικά"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Συγχρονισμός τώρα",
+      "description": "Ξεκινά συγχρονισμό αμέσως, χωρίς αναμονή για το διάστημα."
+    },
+    "preview": {
+      "name": "Προεπισκόπηση συγχρονισμού",
+      "description": "Καταγράφει ποιες σελίδες θα δημιουργούνταν/ενημερώνονταν χωρίς να γράφει τίποτα στο BookStack."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Κατάσταση συγχρονισμού",
+        "state": {
+          "ok": "OK",
+          "error": "Σφάλμα",
+          "never_run": "Δεν έχει εκτελεστεί ποτέ",
+          "syncing": "Συγχρονισμός σε εξέλιξη"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Συγχρονισμός τώρα"
+      },
+      "preview": {
+        "name": "Προεπισκόπηση συγχρονισμού (δοκιμαστική)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "Το BookStack δεν είναι προσβάσιμο",
+      "description": "Η ενσωμάτωση BookStack Sync δεν μπόρεσε να φτάσει στην εγκατάσταση BookStack για {count} συνεχόμενους συγχρονισμούς. Συνηθισμένες αιτίες: το BookStack container είναι σταματημένο, πρόβλημα δικτύου ή reverse proxy απορρίπτει συνδέσεις. Ο επόμενος επιτυχής συγχρονισμός επιλύει αυτή την ειδοποίηση αυτόματα."
+    },
+    "page_tampered": {
+      "title": "Το AUTO block μιας σελίδας έχει επεξεργαστεί χειροκίνητα",
+      "description": "Η σελίδα „{page_title}\" στο BookStack έχει AUTO block που επεξεργάστηκε εκτός Home Assistant. Η ενσωμάτωση παρέλειψε αυτή τη σελίδα κατά τον συγχρονισμό για να μην αντικαταστήσει τις αλλαγές σας. Μετακινήστε τις σημειώσεις σας στο MANUAL block ή αναιρέστε την αλλαγή στο AUTO block, ώστε ο επόμενος συγχρονισμός να ενημερώσει ξανά τη σελίδα."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "Η εγκατάσταση BookStack δεν είναι προσβάσιμη (δείτε το αρχείο καταγραφής Home Assistant για λεπτομέρειες)."
+    },
+    "bookstack_auth_failed": {
+      "message": "Το BookStack απέρριψε το API token. Ανανεώστε το token στο BookStack και χρησιμοποιήστε τη ροή Reauth."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/es.json
+++ b/custom_components/bookstack_sync/translations/es.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Conexión a BookStack",
+        "description": "Conecta Home Assistant a tu instancia de BookStack.\n\nEn BookStack ve a *Mi cuenta → Tokens API*, crea un token y pega el ID y el secreto aquí.\n\nDocumentación: {documentation_url}",
+        "data": {
+          "base_url": "URL de BookStack",
+          "token_id": "ID del token API",
+          "token_secret": "Secreto del token API",
+          "verify_ssl": "Verificar certificado TLS (desactiva para autofirmados)"
+        }
+      },
+      "book": {
+        "title": "Elige libro de destino",
+        "description": "¿En qué libro debe sincronizar Home Assistant? El contenido añadido manualmente dentro de las páginas se conserva.",
+        "data": {
+          "book_id": "Libro de destino",
+          "sync_interval": "Intervalo de sincronización"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Renovar token de BookStack",
+        "description": "BookStack rechazó el token API para {base_url}. Crea un nuevo token en BookStack y pega el ID y el secreto aquí — la URL y el libro de destino permanecen iguales.",
+        "data": {
+          "token_id": "ID del token API",
+          "token_secret": "Secreto del token API"
+        }
+      },
+      "reconfigure": {
+        "title": "Ajustar conexión a BookStack",
+        "description": "Cambia URL, token o ajuste TLS de esta conexión. El libro de destino y todas las asignaciones de páginas se conservan. La URL debe apuntar a la misma instancia de BookStack que antes.",
+        "data": {
+          "base_url": "URL de BookStack",
+          "token_id": "ID del token API",
+          "token_secret": "Secreto del token API",
+          "verify_ssl": "Verificar certificado TLS (desactiva para autofirmados)"
+        }
+      }
+    },
+    "error": {
+      "auth": "Token API rechazado o permisos insuficientes.",
+      "connection": "No se puede acceder a BookStack.",
+      "no_books": "No se encontró ningún libro en esta instancia de BookStack. Crea primero un libro de destino.",
+      "unknown": "Error inesperado — revisa el registro de Home Assistant.",
+      "base_url_invalid_scheme": "La URL debe empezar por http:// o https://.",
+      "base_url_missing_host": "La URL está incompleta — falta el nombre de host."
+    },
+    "abort": {
+      "already_configured": "Esta instancia de BookStack ya está configurada.",
+      "reauth_successful": "Token renovado — conexión a BookStack restaurada.",
+      "reconfigure_successful": "Conexión actualizada — BookStack Sync se ha reconfigurado.",
+      "url_mismatch": "La nueva URL apunta a una instancia distinta de BookStack. Elimina la entrada original y añade una nueva."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Ajustes de BookStack Sync",
+        "data": {
+          "book_id": "Libro de destino",
+          "sync_interval": "Intervalo de sincronización",
+          "excluded_areas": "Áreas excluidas (no se sincronizarán)",
+          "output_language": "Idioma de las páginas de BookStack"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "Cada hora",
+        "daily": "Diariamente",
+        "manual": "Solo manual (llamada al servicio)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Como Home Assistant (auto)",
+        "de": "Alemán",
+        "en": "Inglés"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Sincronizar ahora",
+      "description": "Inicia una sincronización de inmediato, sin esperar al intervalo."
+    },
+    "preview": {
+      "name": "Vista previa de sincronización",
+      "description": "Registra qué páginas se crearían/actualizarían sin escribir nada en BookStack."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Estado de sincronización",
+        "state": {
+          "ok": "OK",
+          "error": "Error",
+          "never_run": "Aún no ejecutado",
+          "syncing": "Sincronización en curso"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Sincronizar ahora"
+      },
+      "preview": {
+        "name": "Vista previa de sincronización (simulación)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack no está accesible",
+      "description": "La integración BookStack Sync no ha podido alcanzar la instancia de BookStack durante {count} sincronizaciones consecutivas. Causas comunes: el contenedor de BookStack está detenido, un problema de red o un proxy inverso rechaza las conexiones. La próxima sincronización exitosa resuelve esta notificación automáticamente."
+    },
+    "page_tampered": {
+      "title": "El bloque AUTO de una página se editó manualmente",
+      "description": "La página \"{page_title}\" en BookStack tiene un bloque AUTO que se editó fuera de Home Assistant. La integración omitió esa página al sincronizar para no sobrescribir tus cambios. Mueve tus notas al bloque MANUAL o revierte el cambio en el bloque AUTO para que la próxima sincronización pueda actualizar la página de nuevo."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "Instancia de BookStack inaccesible (consulta el registro de Home Assistant para más detalles)."
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack rechazó el token API. Renueva el token en BookStack y usa el flujo Reauth."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/et.json
+++ b/custom_components/bookstack_sync/translations/et.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "BookStacki ühendus",
+        "description": "Ühenda Home Assistant oma BookStacki eksemplariga.\n\nBookStackis mine *Minu konto → API-tokenid*, loo token ja kleebi ID ja saladus siia.\n\nDokumentatsioon: {documentation_url}",
+        "data": {
+          "base_url": "BookStacki URL",
+          "token_id": "API-tokeni ID",
+          "token_secret": "API-tokeni saladus",
+          "verify_ssl": "Kontrolli TLS-sertifikaati (lülita välja iseallkirjastatute korral)"
+        }
+      },
+      "book": {
+        "title": "Vali sihtraamat",
+        "description": "Millisesse raamatusse peaks Home Assistant sünkroonima? Käsitsi lehtedele lisatud sisu säilitatakse.",
+        "data": {
+          "book_id": "Sihtraamat",
+          "sync_interval": "Sünkroonimisintervall"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Värskenda BookStacki tokenit",
+        "description": "BookStack lükkas API-tokeni {base_url} jaoks tagasi. Loo uus token BookStackis ja kleebi ID ja saladus siia — URL ja sihtraamat jäävad samaks.",
+        "data": {
+          "token_id": "API-tokeni ID",
+          "token_secret": "API-tokeni saladus"
+        }
+      },
+      "reconfigure": {
+        "title": "Muuda BookStacki ühendust",
+        "description": "Muuda selle ühenduse URL-i, tokenit või TLS-seadistust. Sihtraamat ja kõik leheviited säilitatakse. URL peab osutama samale BookStacki eksemplarile nagu varem.",
+        "data": {
+          "base_url": "BookStacki URL",
+          "token_id": "API-tokeni ID",
+          "token_secret": "API-tokeni saladus",
+          "verify_ssl": "Kontrolli TLS-sertifikaati (lülita välja iseallkirjastatute korral)"
+        }
+      }
+    },
+    "error": {
+      "auth": "API-token tagasi lükatud või õigused puuduvad.",
+      "connection": "BookStacki ei saa ühendada.",
+      "no_books": "Selles BookStacki eksemplaris raamatut ei leitud. Loo esmalt sihtraamat.",
+      "unknown": "Ootamatu viga — kontrolli Home Assistanti logi.",
+      "base_url_invalid_scheme": "URL peab algama http:// või https:// -ga.",
+      "base_url_missing_host": "URL on puudulik — hosti nimi puudub."
+    },
+    "abort": {
+      "already_configured": "See BookStacki eksemplar on juba seadistatud.",
+      "reauth_successful": "Token värskendatud — BookStacki ühendus taastatud.",
+      "reconfigure_successful": "Ühendus uuendatud — BookStack Sync on uuesti seadistatud.",
+      "url_mismatch": "Uus URL osutab teisele BookStacki eksemplarile. Eemalda algne kirje ja lisa uus."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "BookStack Synci seaded",
+        "data": {
+          "book_id": "Sihtraamat",
+          "sync_interval": "Sünkroonimisintervall",
+          "excluded_areas": "Välistatud alad (ei sünkroonita)",
+          "output_language": "BookStacki lehtede keel"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "Tunnis",
+        "daily": "Iga päev",
+        "manual": "Ainult käsitsi (teenusekutse)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Nagu Home Assistant (automaatne)",
+        "de": "Saksa",
+        "en": "Inglise"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Sünkrooni kohe",
+      "description": "Käivitab sünkroonimise kohe, ilma intervalli ootamata."
+    },
+    "preview": {
+      "name": "Sünkroonimise eelvaade",
+      "description": "Logib, milliseid lehti loodaks/uuendataks, ilma BookStacki midagi kirjutamata."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Sünkroonimisolek",
+        "state": {
+          "ok": "OK",
+          "error": "Viga",
+          "never_run": "Pole veel käivitatud",
+          "syncing": "Sünkroonimine käib"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Sünkrooni kohe"
+      },
+      "preview": {
+        "name": "Sünkroonimise eelvaade (proovikäik)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack pole kättesaadav",
+      "description": "BookStack Synci integratsioon ei suutnud BookStacki eksemplarile {count} järjestikuse sünkroonimise jooksul ligi pääseda. Tavalised põhjused: BookStacki konteiner on peatatud, võrguprobleem või pöördpuhverserver lükkab ühendused tagasi. Järgmine edukas sünkroonimine lahendab selle teate automaatselt."
+    },
+    "page_tampered": {
+      "title": "Lehe AUTO-plokki muudeti käsitsi",
+      "description": "Lehel „{page_title}\" BookStackis on AUTO-plokk, mida muudeti väljaspool Home Assistanti. Integratsioon jättis selle lehe sünkroonimise vahele, et mitte kirjutada sinu muudatusi üle. Liiguta oma märkmed MANUAL-plokki või tühista AUTO-ploki muudatus, et järgmine sünkroonimine saaks lehte uuesti uuendada."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "BookStacki eksemplar pole kättesaadav (üksikasju vaata Home Assistanti logist)."
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack lükkas API-tokeni tagasi. Värskenda token BookStackis ja kasuta Reauth-protsessi."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/fi.json
+++ b/custom_components/bookstack_sync/translations/fi.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "BookStack-yhteys",
+        "description": "Yhdistä Home Assistant BookStack-instanssiisi.\n\nMene BookStackissa kohtaan *Oma tili → API-tunnukset*, luo tunnus ja liitä tunnus ja salaisuus tähän.\n\nDokumentaatio: {documentation_url}",
+        "data": {
+          "base_url": "BookStack-URL",
+          "token_id": "API-tunnuksen tunniste",
+          "token_secret": "API-tunnuksen salaisuus",
+          "verify_ssl": "Vahvista TLS-varmenne (poista käytöstä itse allekirjoitetuilla)"
+        }
+      },
+      "book": {
+        "title": "Valitse kohdekirja",
+        "description": "Mihin kirjaan Home Assistantin tulisi synkronoida? Sivuille manuaalisesti lisätty sisältö säilyy.",
+        "data": {
+          "book_id": "Kohdekirja",
+          "sync_interval": "Synkronointiväli"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Päivitä BookStack-tunnus",
+        "description": "BookStack hylkäsi API-tunnuksen osoitteelle {base_url}. Luo uusi tunnus BookStackissa ja liitä tunnus ja salaisuus tähän — URL ja kohdekirja pysyvät ennallaan.",
+        "data": {
+          "token_id": "API-tunnuksen tunniste",
+          "token_secret": "API-tunnuksen salaisuus"
+        }
+      },
+      "reconfigure": {
+        "title": "Säädä BookStack-yhteyttä",
+        "description": "Vaihda tämän yhteyden URL, tunnus tai TLS-asetus. Kohdekirja ja kaikki sivumääritykset säilyvät. URL:n on osoitettava samaan BookStack-instanssiin kuin aiemmin.",
+        "data": {
+          "base_url": "BookStack-URL",
+          "token_id": "API-tunnuksen tunniste",
+          "token_secret": "API-tunnuksen salaisuus",
+          "verify_ssl": "Vahvista TLS-varmenne (poista käytöstä itse allekirjoitetuilla)"
+        }
+      }
+    },
+    "error": {
+      "auth": "API-tunnus hylätty tai oikeudet puuttuvat.",
+      "connection": "BookStackiin ei saada yhteyttä.",
+      "no_books": "Tästä BookStack-instanssista ei löytynyt kirjaa. Luo ensin kohdekirja.",
+      "unknown": "Odottamaton virhe — tarkista Home Assistantin loki.",
+      "base_url_invalid_scheme": "URL:n on alettava merkinnällä http:// tai https://.",
+      "base_url_missing_host": "URL on epätäydellinen — isäntänimi puuttuu."
+    },
+    "abort": {
+      "already_configured": "Tämä BookStack-instanssi on jo määritetty.",
+      "reauth_successful": "Tunnus päivitetty — BookStack-yhteys palautettu.",
+      "reconfigure_successful": "Yhteys päivitetty — BookStack Sync on määritetty uudelleen.",
+      "url_mismatch": "Uusi URL osoittaa eri BookStack-instanssiin. Poista alkuperäinen merkintä ja lisää uusi."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "BookStack Sync -asetukset",
+        "data": {
+          "book_id": "Kohdekirja",
+          "sync_interval": "Synkronointiväli",
+          "excluded_areas": "Pois jätetyt alueet (ei synkronoida)",
+          "output_language": "BookStack-sivujen kieli"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "Tunneittain",
+        "daily": "Päivittäin",
+        "manual": "Vain manuaalisesti (palvelukutsu)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Kuten Home Assistant (auto)",
+        "de": "Saksa",
+        "en": "Englanti"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Synkronoi nyt",
+      "description": "Käynnistää synkronoinnin heti odottamatta väliä."
+    },
+    "preview": {
+      "name": "Synkronoinnin esikatselu",
+      "description": "Kirjaa, mitkä sivut luotaisiin/päivitettäisiin, mutta ei kirjoita mitään BookStackiin."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Synkronoinnin tila",
+        "state": {
+          "ok": "OK",
+          "error": "Virhe",
+          "never_run": "Ei vielä suoritettu",
+          "syncing": "Synkronointi käynnissä"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Synkronoi nyt"
+      },
+      "preview": {
+        "name": "Synkronoinnin esikatselu (kuiva-ajo)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack ei ole tavoitettavissa",
+      "description": "BookStack Sync -integraatio ei ole tavoittanut BookStack-instanssia {count} peräkkäisen synkronoinnin aikana. Yleisiä syitä: BookStack-säiliö on pysäytetty, verkko-ongelma tai käänteinen välityspalvelin hylkää yhteyksiä. Seuraava onnistunut synkronointi ratkaisee tämän ilmoituksen automaattisesti."
+    },
+    "page_tampered": {
+      "title": "Sivun AUTO-lohkoa on muokattu manuaalisesti",
+      "description": "Sivulla „{page_title}\" BookStackissa on AUTO-lohko, jota muokattiin Home Assistantin ulkopuolella. Integraatio ohitti tämän sivun synkronoinnissa, jotta muutoksiasi ei korvattaisi. Siirrä muistiinpanosi MANUAL-lohkoon tai peruuta AUTO-lohkon muutos, jotta seuraava synkronointi voi päivittää sivun uudelleen."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "BookStack-instanssi ei ole tavoitettavissa (lisätietoja Home Assistantin lokista)."
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack hylkäsi API-tunnuksen. Päivitä tunnus BookStackissa ja käytä Reauth-prosessia."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/fr.json
+++ b/custom_components/bookstack_sync/translations/fr.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connexion BookStack",
+        "description": "Connectez Home Assistant à votre instance BookStack.\n\nDans BookStack, allez dans *Mon compte → Tokens API*, créez un token et collez l'ID et le secret ici.\n\nDocumentation : {documentation_url}",
+        "data": {
+          "base_url": "URL BookStack",
+          "token_id": "ID du token API",
+          "token_secret": "Secret du token API",
+          "verify_ssl": "Vérifier le certificat TLS (désactivez pour les certificats auto-signés)"
+        }
+      },
+      "book": {
+        "title": "Choisir le livre cible",
+        "description": "Vers quel livre Home Assistant doit-il synchroniser ? Le contenu ajouté manuellement aux pages est conservé.",
+        "data": {
+          "book_id": "Livre cible",
+          "sync_interval": "Intervalle de synchronisation"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Renouveler le token BookStack",
+        "description": "BookStack a refusé le token API pour {base_url}. Créez un nouveau token dans BookStack et collez l'ID et le secret ici — l'URL et le livre cible restent inchangés.",
+        "data": {
+          "token_id": "ID du token API",
+          "token_secret": "Secret du token API"
+        }
+      },
+      "reconfigure": {
+        "title": "Modifier la connexion BookStack",
+        "description": "Modifiez l'URL, le token ou le réglage TLS de cette connexion. Le livre cible et toutes les associations de pages sont conservés. L'URL doit pointer vers la même instance BookStack qu'auparavant.",
+        "data": {
+          "base_url": "URL BookStack",
+          "token_id": "ID du token API",
+          "token_secret": "Secret du token API",
+          "verify_ssl": "Vérifier le certificat TLS (désactivez pour les certificats auto-signés)"
+        }
+      }
+    },
+    "error": {
+      "auth": "Token API refusé ou autorisations manquantes.",
+      "connection": "Impossible de joindre BookStack.",
+      "no_books": "Aucun livre trouvé dans cette instance BookStack. Créez d'abord un livre cible.",
+      "unknown": "Erreur inattendue — consultez le journal Home Assistant.",
+      "base_url_invalid_scheme": "L'URL doit commencer par http:// ou https://.",
+      "base_url_missing_host": "L'URL est incomplète — nom d'hôte manquant."
+    },
+    "abort": {
+      "already_configured": "Cette instance BookStack est déjà configurée.",
+      "reauth_successful": "Token renouvelé — connexion BookStack rétablie.",
+      "reconfigure_successful": "Connexion mise à jour — BookStack Sync a été reconfiguré.",
+      "url_mismatch": "La nouvelle URL pointe vers une autre instance BookStack. Veuillez supprimer l'entrée d'origine et en ajouter une nouvelle."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Paramètres BookStack Sync",
+        "data": {
+          "book_id": "Livre cible",
+          "sync_interval": "Intervalle de synchronisation",
+          "excluded_areas": "Zones exclues (ne seront pas synchronisées)",
+          "output_language": "Langue des pages BookStack"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "Toutes les heures",
+        "daily": "Quotidiennement",
+        "manual": "Manuel uniquement (appel de service)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Comme Home Assistant (auto)",
+        "de": "Allemand",
+        "en": "Anglais"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Synchroniser maintenant",
+      "description": "Démarre une synchronisation immédiatement, sans attendre l'intervalle."
+    },
+    "preview": {
+      "name": "Aperçu de synchronisation",
+      "description": "Enregistre quelles pages seraient créées/mises à jour sans rien écrire dans BookStack."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "État de synchronisation",
+        "state": {
+          "ok": "OK",
+          "error": "Erreur",
+          "never_run": "Jamais exécuté",
+          "syncing": "Synchronisation en cours"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Synchroniser maintenant"
+      },
+      "preview": {
+        "name": "Aperçu de synchronisation (à blanc)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack est inaccessible",
+      "description": "L'intégration BookStack Sync n'a pas pu joindre l'instance BookStack pendant {count} synchronisations consécutives. Causes courantes : le conteneur BookStack est arrêté, un problème réseau, ou un proxy inverse refuse les connexions. La prochaine synchronisation réussie résout cette notification automatiquement."
+    },
+    "page_tampered": {
+      "title": "Le bloc AUTO d'une page a été modifié manuellement",
+      "description": "La page « {page_title} » dans BookStack contient un bloc AUTO modifié en dehors de Home Assistant. L'intégration a ignoré cette page lors de la synchronisation pour ne pas écraser vos modifications. Déplacez vos notes dans le bloc MANUAL ou annulez la modification du bloc AUTO afin que la prochaine synchronisation puisse à nouveau mettre à jour la page."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "Instance BookStack inaccessible (consultez le journal Home Assistant pour plus de détails)."
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack a refusé le token API. Renouvelez le token dans BookStack et utilisez le flux Reauth."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/ga.json
+++ b/custom_components/bookstack_sync/translations/ga.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Ceangal BookStack",
+        "description": "Ceangail Home Assistant le do shampla BookStack.\n\nIn BookStack téigh go *Mo chuntas → Comharthaí API*, cruthaigh comhartha agus greamaigh an ID agus an rún anseo.\n\nDoiciméadúchán: {documentation_url}",
+        "data": {
+          "base_url": "URL BookStack",
+          "token_id": "ID an chomhartha API",
+          "token_secret": "Rún an chomhartha API",
+          "verify_ssl": "Fíoraigh teastas TLS (díchumasaigh i gcás féin-shínithe)"
+        }
+      },
+      "book": {
+        "title": "Roghnaigh leabhar sprice",
+        "description": "Cén leabhar inar chóir do Home Assistant sioncronú? Coinneofar ábhar a cuireadh leis na leathanaigh de láimh.",
+        "data": {
+          "book_id": "Leabhar sprice",
+          "sync_interval": "Eatramh sioncronaithe"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Athnuaigh comhartha BookStack",
+        "description": "Dhiúltaigh BookStack don chomhartha API le haghaidh {base_url}. Cruthaigh comhartha nua i BookStack agus greamaigh an ID agus an rún anseo — fanann an URL agus an leabhar sprice mar an gcéanna.",
+        "data": {
+          "token_id": "ID an chomhartha API",
+          "token_secret": "Rún an chomhartha API"
+        }
+      },
+      "reconfigure": {
+        "title": "Coigeartaigh ceangal BookStack",
+        "description": "Athraigh URL, comhartha nó socrú TLS an cheangail seo. Coinnítear an leabhar sprice agus na mapálacha leathanaigh go léir. Ní mór don URL pointeáil chuig an sampla BookStack céanna agus a bhí roimhe seo.",
+        "data": {
+          "base_url": "URL BookStack",
+          "token_id": "ID an chomhartha API",
+          "token_secret": "Rún an chomhartha API",
+          "verify_ssl": "Fíoraigh teastas TLS (díchumasaigh i gcás féin-shínithe)"
+        }
+      }
+    },
+    "error": {
+      "auth": "Diúltaíodh don chomhartha API nó tá ceadanna in easnamh.",
+      "connection": "Ní féidir BookStack a shroicheadh.",
+      "no_books": "Níor aimsíodh aon leabhar sa sampla BookStack seo. Cruthaigh leabhar sprice ar dtús.",
+      "unknown": "Earráid gan choinne — seiceáil loga Home Assistant.",
+      "base_url_invalid_scheme": "Ní mór do URL tosú le http:// nó https://.",
+      "base_url_missing_host": "Tá an URL neamhiomlán — ainm óstaigh ar iarraidh."
+    },
+    "abort": {
+      "already_configured": "Tá an sampla BookStack seo cumraithe cheana féin.",
+      "reauth_successful": "Comhartha athnuaite — ceangal BookStack athbhunaithe.",
+      "reconfigure_successful": "Ceangal nuashonraithe — atchumraíodh BookStack Sync.",
+      "url_mismatch": "Pointeálann an URL nua chuig sampla BookStack difriúil. Bain an iontráil bhunaidh agus cuir ceann nua leis."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Socruithe BookStack Sync",
+        "data": {
+          "book_id": "Leabhar sprice",
+          "sync_interval": "Eatramh sioncronaithe",
+          "excluded_areas": "Limistéir eisiata (ní dhéanfar sioncronú orthu)",
+          "output_language": "Teanga na leathanach BookStack"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "Gach uair",
+        "daily": "Go laethúil",
+        "manual": "De láimh amháin (glao seirbhíse)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Mar Home Assistant (uathoibríoch)",
+        "de": "Gearmáinis",
+        "en": "Béarla"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Sioncronú anois",
+      "description": "Tosaíonn sioncronú láithreach gan fanacht leis an eatramh."
+    },
+    "preview": {
+      "name": "Réamhamharc sioncronaithe",
+      "description": "Logáil cad iad na leathanaigh a chruthófaí/nuashonrófaí gan rud ar bith a scríobh chuig BookStack."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Stádas sioncronaithe",
+        "state": {
+          "ok": "OK",
+          "error": "Earráid",
+          "never_run": "Níor ritheadh fós",
+          "syncing": "Sioncronú ar siúl"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Sioncronú anois"
+      },
+      "preview": {
+        "name": "Réamhamharc sioncronaithe (rith tirim)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "Tá BookStack do-rochtana",
+      "description": "Níor éirigh leis an gcomhtháthú BookStack Sync an sampla BookStack a shroicheadh i {count} sioncronaithe as a chéile. Cúiseanna coitianta: tá an coimeádán BookStack stoptha, fadhb líonra, nó tá seachfhreastalaí droim ar ais ag diúltú do na ceangail. Réiteoidh an chéad sioncronú rathúil eile an fógra seo go huathoibríoch."
+    },
+    "page_tampered": {
+      "title": "Cuireadh bloc AUTO de leathanach in eagar de láimh",
+      "description": "Tá bloc AUTO ag an leathanach „{page_title}\" i BookStack a cuireadh in eagar lasmuigh de Home Assistant. Lig an comhtháthú thar an leathanach seo le linn sioncronaithe chun gan d'athruithe a fhorscríobh. Bog do nótaí go dtí an bloc MANUAL nó cealaigh an t-athrú sa bhloc AUTO ionas gur féidir leis an gcéad sioncronú eile an leathanach a nuashonrú arís."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "Tá an sampla BookStack do-rochtana (féach loga Home Assistant le haghaidh sonraí)."
+    },
+    "bookstack_auth_failed": {
+      "message": "Dhiúltaigh BookStack don chomhartha API. Athnuaigh an comhartha i BookStack agus úsáid sreabh Reauth."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/hr.json
+++ b/custom_components/bookstack_sync/translations/hr.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "BookStack veza",
+        "description": "Povežite Home Assistant sa svojom BookStack instancom.\n\nU BookStacku idite na *Moj račun → API tokeni*, kreirajte token i zalijepite ID i tajnu ovdje.\n\nDokumentacija: {documentation_url}",
+        "data": {
+          "base_url": "BookStack URL",
+          "token_id": "ID API tokena",
+          "token_secret": "Tajna API tokena",
+          "verify_ssl": "Provjeri TLS certifikat (onemogući za samopotpisane)"
+        }
+      },
+      "book": {
+        "title": "Odaberite ciljnu knjigu",
+        "description": "U koju knjigu Home Assistant treba sinkronizirati? Ručno dodani sadržaj na stranicama bit će sačuvan.",
+        "data": {
+          "book_id": "Ciljna knjiga",
+          "sync_interval": "Interval sinkronizacije"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Obnovi BookStack token",
+        "description": "BookStack je odbio API token za {base_url}. Kreirajte novi token u BookStacku i zalijepite ID i tajnu ovdje — URL i ciljna knjiga ostaju isti.",
+        "data": {
+          "token_id": "ID API tokena",
+          "token_secret": "Tajna API tokena"
+        }
+      },
+      "reconfigure": {
+        "title": "Prilagodi BookStack vezu",
+        "description": "Promijenite URL, token ili TLS postavku ove veze. Ciljna knjiga i sva mapiranja stranica bit će sačuvana. URL mora pokazivati na istu BookStack instancu kao prije.",
+        "data": {
+          "base_url": "BookStack URL",
+          "token_id": "ID API tokena",
+          "token_secret": "Tajna API tokena",
+          "verify_ssl": "Provjeri TLS certifikat (onemogući za samopotpisane)"
+        }
+      }
+    },
+    "error": {
+      "auth": "API token odbijen ili nedostaju dozvole.",
+      "connection": "Nije moguće doći do BookStacka.",
+      "no_books": "U ovoj BookStack instanci nije pronađena nijedna knjiga. Najprije kreirajte ciljnu knjigu.",
+      "unknown": "Neočekivana pogreška — provjerite Home Assistant zapisnik.",
+      "base_url_invalid_scheme": "URL mora započinjati s http:// ili https://.",
+      "base_url_missing_host": "URL je nepotpun — naziv hosta nedostaje."
+    },
+    "abort": {
+      "already_configured": "Ova BookStack instanca je već konfigurirana.",
+      "reauth_successful": "Token obnovljen — BookStack veza obnovljena.",
+      "reconfigure_successful": "Veza ažurirana — BookStack Sync je rekonfiguriran.",
+      "url_mismatch": "Novi URL pokazuje na drugu BookStack instancu. Uklonite izvorni unos i dodajte novi."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Postavke BookStack Sync",
+        "data": {
+          "book_id": "Ciljna knjiga",
+          "sync_interval": "Interval sinkronizacije",
+          "excluded_areas": "Isključena područja (neće se sinkronizirati)",
+          "output_language": "Jezik BookStack stranica"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "Svakog sata",
+        "daily": "Dnevno",
+        "manual": "Samo ručno (poziv usluge)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Kao Home Assistant (auto)",
+        "de": "Njemački",
+        "en": "Engleski"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Sinkroniziraj sada",
+      "description": "Pokreće sinkronizaciju odmah, bez čekanja na interval."
+    },
+    "preview": {
+      "name": "Pregled sinkronizacije",
+      "description": "Bilježi koje bi se stranice kreirale/ažurirale, ali ne piše ništa u BookStack."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Status sinkronizacije",
+        "state": {
+          "ok": "OK",
+          "error": "Greška",
+          "never_run": "Još nije pokrenuto",
+          "syncing": "Sinkronizacija u tijeku"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Sinkroniziraj sada"
+      },
+      "preview": {
+        "name": "Pregled sinkronizacije (suho pokretanje)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack je nedostupan",
+      "description": "Integracija BookStack Sync nije mogla doći do BookStack instance kroz {count} uzastopnih sinkronizacija. Uobičajeni uzroci: BookStack kontejner je zaustavljen, mrežni problem ili reverse proxy odbija veze. Sljedeća uspješna sinkronizacija automatski rješava ovu obavijest."
+    },
+    "page_tampered": {
+      "title": "AUTO blok stranice je ručno uređen",
+      "description": "Stranica „{page_title}\" u BookStacku ima AUTO blok koji je uređen izvan Home Assistanta. Integracija je preskočila tu stranicu pri sinkronizaciji kako ne bi prepisala vaše izmjene. Premjestite svoje bilješke u MANUAL blok ili poništite promjenu u AUTO bloku kako bi sljedeća sinkronizacija mogla ponovno ažurirati stranicu."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "BookStack instanca nedostupna (pojedinosti potražite u Home Assistant zapisniku)."
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack je odbio API token. Obnovite token u BookStacku i koristite Reauth tijek."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/hu.json
+++ b/custom_components/bookstack_sync/translations/hu.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "BookStack kapcsolat",
+        "description": "Kösse össze a Home Assistantot a BookStack példányával.\n\nA BookStackben menjen a *Saját fiók → API tokenek* menüpontra, hozzon létre egy tokent, és illessze be ide az azonosítót és a titkos kulcsot.\n\nDokumentáció: {documentation_url}",
+        "data": {
+          "base_url": "BookStack URL",
+          "token_id": "API token azonosító",
+          "token_secret": "API token titkos kulcs",
+          "verify_ssl": "TLS tanúsítvány ellenőrzése (önaláírtaknál kapcsolja ki)"
+        }
+      },
+      "book": {
+        "title": "Válasszon célkönyvet",
+        "description": "Melyik könyvbe szinkronizáljon a Home Assistant? A kézzel hozzáadott tartalom az oldalakon megmarad.",
+        "data": {
+          "book_id": "Célkönyv",
+          "sync_interval": "Szinkronizálási időköz"
+        }
+      },
+      "reauth_confirm": {
+        "title": "BookStack token frissítése",
+        "description": "A BookStack elutasította az API tokent a {base_url} címhez. Hozzon létre új tokent a BookStackben, és illessze be ide az azonosítót és a titkos kulcsot — az URL és a célkönyv változatlan marad.",
+        "data": {
+          "token_id": "API token azonosító",
+          "token_secret": "API token titkos kulcs"
+        }
+      },
+      "reconfigure": {
+        "title": "BookStack kapcsolat módosítása",
+        "description": "Módosítsa az URL-t, tokent vagy TLS beállítást a kapcsolathoz. A célkönyv és minden oldalhozzárendelés megmarad. Az URL-nek ugyanarra a BookStack példányra kell mutatnia, mint korábban.",
+        "data": {
+          "base_url": "BookStack URL",
+          "token_id": "API token azonosító",
+          "token_secret": "API token titkos kulcs",
+          "verify_ssl": "TLS tanúsítvány ellenőrzése (önaláírtaknál kapcsolja ki)"
+        }
+      }
+    },
+    "error": {
+      "auth": "API tokent elutasították, vagy hiányoznak a jogosultságok.",
+      "connection": "A BookStack nem érhető el.",
+      "no_books": "Nincs könyv ebben a BookStack példányban. Hozzon létre először célkönyvet.",
+      "unknown": "Váratlan hiba — ellenőrizze a Home Assistant naplóját.",
+      "base_url_invalid_scheme": "Az URL-nek http:// vagy https:// karakterekkel kell kezdődnie.",
+      "base_url_missing_host": "Az URL hiányos — a hosztnév hiányzik."
+    },
+    "abort": {
+      "already_configured": "Ez a BookStack példány már konfigurálva van.",
+      "reauth_successful": "Token frissítve — BookStack kapcsolat helyreállt.",
+      "reconfigure_successful": "Kapcsolat frissítve — a BookStack Sync újrakonfigurálva.",
+      "url_mismatch": "Az új URL másik BookStack példányra mutat. Távolítsa el az eredeti bejegyzést, és adjon hozzá újat."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "BookStack Sync beállítások",
+        "data": {
+          "book_id": "Célkönyv",
+          "sync_interval": "Szinkronizálási időköz",
+          "excluded_areas": "Kizárt területek (nem lesznek szinkronizálva)",
+          "output_language": "BookStack oldalak nyelve"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "Óránként",
+        "daily": "Naponta",
+        "manual": "Csak kézzel (szolgáltatáshívás)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Mint a Home Assistant (auto)",
+        "de": "Német",
+        "en": "Angol"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Szinkronizálás most",
+      "description": "Azonnal elindít egy szinkronizálást az időköz bevárása nélkül."
+    },
+    "preview": {
+      "name": "Szinkronizálási előnézet",
+      "description": "Naplózza, mely oldalak jönnének létre/frissülnének, anélkül hogy bármit a BookStackbe írna."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Szinkronizálási állapot",
+        "state": {
+          "ok": "OK",
+          "error": "Hiba",
+          "never_run": "Még nem futott",
+          "syncing": "Szinkronizálás folyamatban"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Szinkronizálás most"
+      },
+      "preview": {
+        "name": "Szinkronizálási előnézet (próbafutás)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "A BookStack nem érhető el",
+      "description": "A BookStack Sync integráció {count} egymást követő szinkronizáláson keresztül nem érte el a BookStack példányt. Gyakori okok: a BookStack tároló le van állítva, hálózati probléma vagy fordított proxy elutasítja a kapcsolatokat. A következő sikeres szinkronizálás automatikusan feloldja ezt az értesítést."
+    },
+    "page_tampered": {
+      "title": "Egy oldal AUTO blokkja kézzel lett szerkesztve",
+      "description": "A „{page_title}\" oldal a BookStackben olyan AUTO blokkot tartalmaz, amelyet a Home Assistanton kívül szerkesztettek. Az integráció kihagyta ezt az oldalt szinkronizálás közben, hogy ne írja felül a módosításokat. Helyezze át jegyzeteit a MANUAL blokkba, vagy vonja vissza a változtatást az AUTO blokkban, hogy a következő szinkronizálás újra frissíthesse az oldalt."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "A BookStack példány nem érhető el (részletekért lásd a Home Assistant naplót)."
+    },
+    "bookstack_auth_failed": {
+      "message": "A BookStack elutasította az API tokent. Frissítse a tokent a BookStackben, és használja a Reauth folyamatot."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/it.json
+++ b/custom_components/bookstack_sync/translations/it.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connessione BookStack",
+        "description": "Collega Home Assistant alla tua istanza BookStack.\n\nIn BookStack vai su *Il mio account → Token API*, crea un token e incolla qui ID e segreto.\n\nDocumentazione: {documentation_url}",
+        "data": {
+          "base_url": "URL BookStack",
+          "token_id": "ID del token API",
+          "token_secret": "Segreto del token API",
+          "verify_ssl": "Verifica certificato TLS (disabilita per certificati autofirmati)"
+        }
+      },
+      "book": {
+        "title": "Scegli libro di destinazione",
+        "description": "In quale libro deve sincronizzare Home Assistant? I contenuti aggiunti manualmente nelle pagine vengono mantenuti.",
+        "data": {
+          "book_id": "Libro di destinazione",
+          "sync_interval": "Intervallo di sincronizzazione"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Rinnova token BookStack",
+        "description": "BookStack ha rifiutato il token API per {base_url}. Crea un nuovo token in BookStack e incolla qui ID e segreto — URL e libro di destinazione restano invariati.",
+        "data": {
+          "token_id": "ID del token API",
+          "token_secret": "Segreto del token API"
+        }
+      },
+      "reconfigure": {
+        "title": "Modifica connessione BookStack",
+        "description": "Modifica URL, token o impostazione TLS di questa connessione. Il libro di destinazione e tutte le associazioni delle pagine vengono mantenute. L'URL deve puntare alla stessa istanza BookStack di prima.",
+        "data": {
+          "base_url": "URL BookStack",
+          "token_id": "ID del token API",
+          "token_secret": "Segreto del token API",
+          "verify_ssl": "Verifica certificato TLS (disabilita per certificati autofirmati)"
+        }
+      }
+    },
+    "error": {
+      "auth": "Token API rifiutato o autorizzazioni mancanti.",
+      "connection": "Impossibile raggiungere BookStack.",
+      "no_books": "Nessun libro trovato in questa istanza BookStack. Crea prima un libro di destinazione.",
+      "unknown": "Errore imprevisto — controlla il registro di Home Assistant.",
+      "base_url_invalid_scheme": "L'URL deve iniziare con http:// o https://.",
+      "base_url_missing_host": "L'URL è incompleto — manca il nome host."
+    },
+    "abort": {
+      "already_configured": "Questa istanza BookStack è già configurata.",
+      "reauth_successful": "Token rinnovato — connessione BookStack ripristinata.",
+      "reconfigure_successful": "Connessione aggiornata — BookStack Sync è stato riconfigurato.",
+      "url_mismatch": "Il nuovo URL punta a un'altra istanza BookStack. Rimuovi la voce originale e aggiungine una nuova."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Impostazioni BookStack Sync",
+        "data": {
+          "book_id": "Libro di destinazione",
+          "sync_interval": "Intervallo di sincronizzazione",
+          "excluded_areas": "Aree escluse (non saranno sincronizzate)",
+          "output_language": "Lingua delle pagine BookStack"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "Ogni ora",
+        "daily": "Ogni giorno",
+        "manual": "Solo manuale (chiamata di servizio)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Come Home Assistant (auto)",
+        "de": "Tedesco",
+        "en": "Inglese"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Sincronizza ora",
+      "description": "Avvia immediatamente una sincronizzazione senza attendere l'intervallo."
+    },
+    "preview": {
+      "name": "Anteprima sincronizzazione",
+      "description": "Registra quali pagine verrebbero create/aggiornate senza scrivere nulla in BookStack."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Stato sincronizzazione",
+        "state": {
+          "ok": "OK",
+          "error": "Errore",
+          "never_run": "Mai eseguito",
+          "syncing": "Sincronizzazione in corso"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Sincronizza ora"
+      },
+      "preview": {
+        "name": "Anteprima sincronizzazione (esecuzione di prova)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack non raggiungibile",
+      "description": "L'integrazione BookStack Sync non ha potuto raggiungere l'istanza BookStack durante {count} sincronizzazioni consecutive. Cause comuni: il container BookStack è fermo, problema di rete o un reverse proxy rifiuta le connessioni. La prossima sincronizzazione riuscita risolverà automaticamente questa notifica."
+    },
+    "page_tampered": {
+      "title": "Il blocco AUTO di una pagina è stato modificato manualmente",
+      "description": "La pagina «{page_title}» in BookStack ha un blocco AUTO che è stato modificato al di fuori di Home Assistant. L'integrazione ha saltato questa pagina durante la sincronizzazione per non sovrascrivere le tue modifiche. Sposta i tuoi appunti nel blocco MANUAL o annulla la modifica nel blocco AUTO affinché la prossima sincronizzazione possa aggiornare di nuovo la pagina."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "Istanza BookStack non raggiungibile (vedi il registro di Home Assistant per i dettagli)."
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack ha rifiutato il token API. Rinnova il token in BookStack e usa il flusso Reauth."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/lt.json
+++ b/custom_components/bookstack_sync/translations/lt.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "BookStack ryšys",
+        "description": "Sujunkite Home Assistant su savo BookStack egzemplioriumi.\n\nBookStack eikite į *Mano paskyra → API raktai*, sukurkite raktą ir įklijuokite ID ir paslaptį čia.\n\nDokumentacija: {documentation_url}",
+        "data": {
+          "base_url": "BookStack URL",
+          "token_id": "API rakto ID",
+          "token_secret": "API rakto paslaptis",
+          "verify_ssl": "Patikrinti TLS sertifikatą (išjunkite, jei pasirašyta savarankiškai)"
+        }
+      },
+      "book": {
+        "title": "Pasirinkite tikslinę knygą",
+        "description": "Į kurią knygą Home Assistant turėtų sinchronizuoti? Rankiniu būdu pridėtas turinys puslapiuose bus išsaugotas.",
+        "data": {
+          "book_id": "Tikslinė knyga",
+          "sync_interval": "Sinchronizavimo intervalas"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Atnaujinti BookStack raktą",
+        "description": "BookStack atmetė API raktą {base_url}. Sukurkite naują raktą BookStack ir įklijuokite ID ir paslaptį čia — URL ir tikslinė knyga lieka tos pačios.",
+        "data": {
+          "token_id": "API rakto ID",
+          "token_secret": "API rakto paslaptis"
+        }
+      },
+      "reconfigure": {
+        "title": "Pakoreguoti BookStack ryšį",
+        "description": "Pakeiskite šio ryšio URL, raktą arba TLS nustatymą. Tikslinė knyga ir visi puslapių susiejimai bus išsaugoti. URL turi nukreipti į tą patį BookStack egzempliorių kaip anksčiau.",
+        "data": {
+          "base_url": "BookStack URL",
+          "token_id": "API rakto ID",
+          "token_secret": "API rakto paslaptis",
+          "verify_ssl": "Patikrinti TLS sertifikatą (išjunkite, jei pasirašyta savarankiškai)"
+        }
+      }
+    },
+    "error": {
+      "auth": "API raktas atmestas arba trūksta leidimų.",
+      "connection": "Nepavyko pasiekti BookStack.",
+      "no_books": "Šiame BookStack egzemplioriuje nerasta jokių knygų. Pirmiausia sukurkite tikslinę knygą.",
+      "unknown": "Netikėta klaida — patikrinkite Home Assistant žurnalą.",
+      "base_url_invalid_scheme": "URL turi prasidėti http:// arba https://.",
+      "base_url_missing_host": "URL nepilnas — trūksta pagrindinio kompiuterio pavadinimo."
+    },
+    "abort": {
+      "already_configured": "Šis BookStack egzempliorius jau sukonfigūruotas.",
+      "reauth_successful": "Raktas atnaujintas — BookStack ryšys atkurtas.",
+      "reconfigure_successful": "Ryšys atnaujintas — BookStack Sync perkonfigūruotas.",
+      "url_mismatch": "Naujas URL nukreipia į kitą BookStack egzempliorių. Pašalinkite pradinį įrašą ir pridėkite naują."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "BookStack Sync nustatymai",
+        "data": {
+          "book_id": "Tikslinė knyga",
+          "sync_interval": "Sinchronizavimo intervalas",
+          "excluded_areas": "Neįtrauktos sritys (nebus sinchronizuojamos)",
+          "output_language": "BookStack puslapių kalba"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "Kas valandą",
+        "daily": "Kasdien",
+        "manual": "Tik rankiniu būdu (paslaugos iškvietimas)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Kaip Home Assistant (auto)",
+        "de": "Vokiečių",
+        "en": "Anglų"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Sinchronizuoti dabar",
+      "description": "Iš karto pradeda sinchronizavimą nelaukiant intervalo."
+    },
+    "preview": {
+      "name": "Sinchronizavimo peržiūra",
+      "description": "Užrašo, kurie puslapiai būtų sukurti/atnaujinti, nieko nerašydama į BookStack."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Sinchronizavimo būsena",
+        "state": {
+          "ok": "OK",
+          "error": "Klaida",
+          "never_run": "Dar nepaleista",
+          "syncing": "Vyksta sinchronizavimas"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Sinchronizuoti dabar"
+      },
+      "preview": {
+        "name": "Sinchronizavimo peržiūra (bandomasis paleidimas)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack nepasiekiamas",
+      "description": "BookStack Sync integracija negalėjo pasiekti BookStack egzemplioriaus per {count} sinchronizavimus iš eilės. Dažniausios priežastys: BookStack konteineris sustabdytas, tinklo problema arba atvirkštinis tarpinis serveris atmeta ryšius. Kitas sėkmingas sinchronizavimas automatiškai išspręs šį pranešimą."
+    },
+    "page_tampered": {
+      "title": "Puslapio AUTO blokas buvo redaguotas rankiniu būdu",
+      "description": "Puslapis „{page_title}\" BookStack turi AUTO bloką, kuris buvo redaguotas už Home Assistant ribų. Integracija praleido šį puslapį sinchronizavimo metu, kad neperrašytų jūsų pakeitimų. Perkelkite užrašus į MANUAL bloką arba atšaukite pakeitimą AUTO bloke, kad kitas sinchronizavimas galėtų vėl atnaujinti puslapį."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "BookStack egzempliorius nepasiekiamas (žr. Home Assistant žurnalą dėl išsamesnės informacijos)."
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack atmetė API raktą. Atnaujinkite raktą BookStack ir naudokite Reauth procesą."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/lv.json
+++ b/custom_components/bookstack_sync/translations/lv.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "BookStack savienojums",
+        "description": "Savienojiet Home Assistant ar savu BookStack instanci.\n\nBookStack dodieties uz *Mans konts → API marķieri*, izveidojiet marķieri un ielīmējiet ID un noslēpumu šeit.\n\nDokumentācija: {documentation_url}",
+        "data": {
+          "base_url": "BookStack URL",
+          "token_id": "API marķiera ID",
+          "token_secret": "API marķiera noslēpums",
+          "verify_ssl": "Pārbaudīt TLS sertifikātu (atspējojiet pašparakstītiem)"
+        }
+      },
+      "book": {
+        "title": "Izvēlieties mērķa grāmatu",
+        "description": "Kurā grāmatā Home Assistant jāsinhronizē? Manuāli pievienots saturs lapās tiek saglabāts.",
+        "data": {
+          "book_id": "Mērķa grāmata",
+          "sync_interval": "Sinhronizācijas intervāls"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Atjaunot BookStack marķieri",
+        "description": "BookStack noraidīja API marķieri {base_url}. Izveidojiet jaunu marķieri BookStack un ielīmējiet ID un noslēpumu šeit — URL un mērķa grāmata paliek nemainīgi.",
+        "data": {
+          "token_id": "API marķiera ID",
+          "token_secret": "API marķiera noslēpums"
+        }
+      },
+      "reconfigure": {
+        "title": "Pielāgot BookStack savienojumu",
+        "description": "Mainiet šī savienojuma URL, marķieri vai TLS iestatījumu. Mērķa grāmata un visi lapu kartējumi tiek saglabāti. URL ir jānorāda uz to pašu BookStack instanci kā iepriekš.",
+        "data": {
+          "base_url": "BookStack URL",
+          "token_id": "API marķiera ID",
+          "token_secret": "API marķiera noslēpums",
+          "verify_ssl": "Pārbaudīt TLS sertifikātu (atspējojiet pašparakstītiem)"
+        }
+      }
+    },
+    "error": {
+      "auth": "API marķieris noraidīts vai trūkst atļauju.",
+      "connection": "Nevar sasniegt BookStack.",
+      "no_books": "Šajā BookStack instancē nav atrasta neviena grāmata. Vispirms izveidojiet mērķa grāmatu.",
+      "unknown": "Negaidīta kļūda — pārbaudiet Home Assistant žurnālu.",
+      "base_url_invalid_scheme": "URL ir jāsākas ar http:// vai https://.",
+      "base_url_missing_host": "URL ir nepilnīgs — trūkst resursdatora nosaukuma."
+    },
+    "abort": {
+      "already_configured": "Šī BookStack instance jau ir konfigurēta.",
+      "reauth_successful": "Marķieris atjaunots — BookStack savienojums atjaunots.",
+      "reconfigure_successful": "Savienojums atjaunināts — BookStack Sync ir pārkonfigurēts.",
+      "url_mismatch": "Jaunais URL norāda uz citu BookStack instanci. Noņemiet sākotnējo ierakstu un pievienojiet jaunu."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "BookStack Sync iestatījumi",
+        "data": {
+          "book_id": "Mērķa grāmata",
+          "sync_interval": "Sinhronizācijas intervāls",
+          "excluded_areas": "Izslēgtie apgabali (netiks sinhronizēti)",
+          "output_language": "BookStack lapu valoda"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "Katru stundu",
+        "daily": "Katru dienu",
+        "manual": "Tikai manuāli (pakalpojuma izsaukums)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Kā Home Assistant (auto)",
+        "de": "Vācu",
+        "en": "Angļu"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Sinhronizēt tagad",
+      "description": "Nekavējoties sāk sinhronizāciju, negaidot intervālu."
+    },
+    "preview": {
+      "name": "Sinhronizācijas priekšskatījums",
+      "description": "Reģistrē, kuras lapas tiktu izveidotas/atjauninātas, nerakstot neko BookStack."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Sinhronizācijas statuss",
+        "state": {
+          "ok": "OK",
+          "error": "Kļūda",
+          "never_run": "Vēl nav palaists",
+          "syncing": "Notiek sinhronizācija"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Sinhronizēt tagad"
+      },
+      "preview": {
+        "name": "Sinhronizācijas priekšskatījums (testa palaišana)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack nav sasniedzams",
+      "description": "BookStack Sync integrācija nevarēja sasniegt BookStack instanci {count} secīgu sinhronizāciju laikā. Bieži cēloņi: BookStack konteiners ir apturēts, tīkla problēma vai apgrieztais starpniekserveris noraida savienojumus. Nākamā veiksmīgā sinhronizācija automātiski atrisinās šo paziņojumu."
+    },
+    "page_tampered": {
+      "title": "Lapas AUTO bloks rediģēts manuāli",
+      "description": "Lapai „{page_title}\" BookStack ir AUTO bloks, kas tika rediģēts ārpus Home Assistant. Integrācija izlaida šo lapu sinhronizācijas laikā, lai nepārrakstītu jūsu izmaiņas. Pārvietojiet piezīmes uz MANUAL bloku vai atsauciet izmaiņas AUTO blokā, lai nākamā sinhronizācija atkal varētu atjaunināt lapu."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "BookStack instance nav sasniedzama (sīkāku informāciju skatiet Home Assistant žurnālā)."
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack noraidīja API marķieri. Atjaunojiet marķieri BookStack un izmantojiet Reauth plūsmu."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/mt.json
+++ b/custom_components/bookstack_sync/translations/mt.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Konnessjoni BookStack",
+        "description": "Qabbad Home Assistant mal-istanza BookStack tiegħek.\n\nF'BookStack mur fuq *Il-kont tiegħi → Tokens API*, oħloq token u waħħal l-ID u s-sigriet hawn.\n\nDokumentazzjoni: {documentation_url}",
+        "data": {
+          "base_url": "URL BookStack",
+          "token_id": "ID tat-token API",
+          "token_secret": "Sigriet tat-token API",
+          "verify_ssl": "Ivverifika ċ-ċertifikat TLS (iddiżattiva għal awtoffirmati)"
+        }
+      },
+      "book": {
+        "title": "Agħżel ktieb mira",
+        "description": "F'liema ktieb għandu jissinkronizza Home Assistant? Il-kontenut miżjud manwalment fuq il-paġni jinżamm.",
+        "data": {
+          "book_id": "Ktieb mira",
+          "sync_interval": "Intervall ta' sinkronizzazzjoni"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Iġġedded it-token BookStack",
+        "description": "BookStack irrifjuta t-token API għal {base_url}. Oħloq token ġdid f'BookStack u waħħal l-ID u s-sigriet hawn — l-URL u l-ktieb mira jibqgħu l-istess.",
+        "data": {
+          "token_id": "ID tat-token API",
+          "token_secret": "Sigriet tat-token API"
+        }
+      },
+      "reconfigure": {
+        "title": "Aġġusta l-konnessjoni BookStack",
+        "description": "Ibdel l-URL, it-token jew l-issettjar TLS ta' din il-konnessjoni. Il-ktieb mira u l-mappings tal-paġni kollha jinżammu. L-URL irid jindika lejn l-istess istanza BookStack ta' qabel.",
+        "data": {
+          "base_url": "URL BookStack",
+          "token_id": "ID tat-token API",
+          "token_secret": "Sigriet tat-token API",
+          "verify_ssl": "Ivverifika ċ-ċertifikat TLS (iddiżattiva għal awtoffirmati)"
+        }
+      }
+    },
+    "error": {
+      "auth": "Token API rrifjutat jew permessi neqsin.",
+      "connection": "Ma jistax jintlaħaq BookStack.",
+      "no_books": "Ma nstab l-ebda ktieb f'din l-istanza BookStack. Oħloq ktieb mira l-ewwel.",
+      "unknown": "Żball mhux mistenni — iċċekkja l-log ta' Home Assistant.",
+      "base_url_invalid_scheme": "L-URL għandu jibda b'http:// jew https://.",
+      "base_url_missing_host": "L-URL huwa inkomplet — l-isem tal-host nieqes."
+    },
+    "abort": {
+      "already_configured": "Din l-istanza BookStack hija diġà kkonfigurata.",
+      "reauth_successful": "It-token ġie mġedded — il-konnessjoni BookStack ġiet irrestawrata.",
+      "reconfigure_successful": "Il-konnessjoni ġiet aġġornata — BookStack Sync ġie rrikonfigurat.",
+      "url_mismatch": "L-URL il-ġdid jindika lejn istanza BookStack oħra. Neħħi d-daħla oriġinali u żid waħda ġdida."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Issettjar BookStack Sync",
+        "data": {
+          "book_id": "Ktieb mira",
+          "sync_interval": "Intervall ta' sinkronizzazzjoni",
+          "excluded_areas": "Żoni esklużi (mhux ser jiġu sinkronizzati)",
+          "output_language": "Lingwa tal-paġni BookStack"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "Kull siegħa",
+        "daily": "Kuljum",
+        "manual": "Manwali biss (sejħa ta' servizz)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Bħal Home Assistant (awto)",
+        "de": "Ġermaniż",
+        "en": "Ingliż"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Sinkronizza issa",
+      "description": "Tibda sinkronizzazzjoni minnufih mingħajr ma tistenna l-intervall."
+    },
+    "preview": {
+      "name": "Anteprima ta' sinkronizzazzjoni",
+      "description": "Tirreġistra liema paġni jinħolqu/jiġu aġġornati mingħajr ma tikteb xejn f'BookStack."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Status tas-sinkronizzazzjoni",
+        "state": {
+          "ok": "OK",
+          "error": "Żball",
+          "never_run": "Għadu ma ġiex eżegwit",
+          "syncing": "Sinkronizzazzjoni għaddejja"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Sinkronizza issa"
+      },
+      "preview": {
+        "name": "Anteprima ta' sinkronizzazzjoni (eżekuzzjoni xotta)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack ma jistax jintlaħaq",
+      "description": "L-integrazzjoni BookStack Sync ma setgħetx tilħaq l-istanza BookStack għal {count} sinkronizzazzjonijiet konsekuttivi. Kawżi komuni: il-container BookStack imwaqqaf, problema fin-netwerk, jew reverse proxy jirrifjuta l-konnessjonijiet. Is-sinkronizzazzjoni li jmiss li tirnexxi tirrisolvi din in-notifika awtomatikament."
+    },
+    "page_tampered": {
+      "title": "Il-blokk AUTO ta' paġna ġie editjat manwalment",
+      "description": "Il-paġna „{page_title}\" f'BookStack għandha blokk AUTO li ġie editjat barra minn Home Assistant. L-integrazzjoni qabżet din il-paġna waqt is-sinkronizzazzjoni biex ma tikteb fuq il-bidliet tiegħek. Mexxi n-noti tiegħek fil-blokk MANUAL jew rrevoka l-bidla fil-blokk AUTO biex is-sinkronizzazzjoni li jmiss tkun tista' taġġorna l-paġna mill-ġdid."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "Istanza BookStack ma tistax tintlaħaq (ara l-log ta' Home Assistant għad-dettalji)."
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack irrifjuta t-token API. Iġġedded it-token f'BookStack u uża l-fluss Reauth."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/nb.json
+++ b/custom_components/bookstack_sync/translations/nb.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "BookStack-tilkobling",
+        "description": "Koble Home Assistant til BookStack-instansen din.\n\nI BookStack går du til *Min konto → API-tokens*, oppretter et token og limer inn ID og hemmelighet her.\n\nDokumentasjon: {documentation_url}",
+        "data": {
+          "base_url": "BookStack-URL",
+          "token_id": "API-token-ID",
+          "token_secret": "API-token-hemmelighet",
+          "verify_ssl": "Verifiser TLS-sertifikat (deaktiver for selvsignerte)"
+        }
+      },
+      "book": {
+        "title": "Velg målbok",
+        "description": "Hvilken bok skal Home Assistant synkronisere til? Manuelt lagt til innhold på sidene blir bevart.",
+        "data": {
+          "book_id": "Målbok",
+          "sync_interval": "Synkroniseringsintervall"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Forny BookStack-token",
+        "description": "BookStack avviste API-tokenet for {base_url}. Opprett et nytt token i BookStack og lim inn ID og hemmelighet her — URL og målbok forblir uendret.",
+        "data": {
+          "token_id": "API-token-ID",
+          "token_secret": "API-token-hemmelighet"
+        }
+      },
+      "reconfigure": {
+        "title": "Juster BookStack-tilkobling",
+        "description": "Endre URL, token eller TLS-innstilling for denne tilkoblingen. Målboken og alle sidetilordninger beholdes. URL-en må peke til samme BookStack-instans som tidligere.",
+        "data": {
+          "base_url": "BookStack-URL",
+          "token_id": "API-token-ID",
+          "token_secret": "API-token-hemmelighet",
+          "verify_ssl": "Verifiser TLS-sertifikat (deaktiver for selvsignerte)"
+        }
+      }
+    },
+    "error": {
+      "auth": "API-token avvist eller tillatelser mangler.",
+      "connection": "Kan ikke nå BookStack.",
+      "no_books": "Ingen bøker funnet i denne BookStack-instansen. Opprett en målbok først.",
+      "unknown": "Uventet feil — sjekk Home Assistant-loggen.",
+      "base_url_invalid_scheme": "URL-en må starte med http:// eller https://.",
+      "base_url_missing_host": "URL-en er ufullstendig — vertsnavnet mangler."
+    },
+    "abort": {
+      "already_configured": "Denne BookStack-instansen er allerede konfigurert.",
+      "reauth_successful": "Token fornyet — BookStack-tilkobling gjenopprettet.",
+      "reconfigure_successful": "Tilkobling oppdatert — BookStack Sync er rekonfigurert.",
+      "url_mismatch": "Den nye URL-en peker til en annen BookStack-instans. Fjern den opprinnelige oppføringen og legg til en ny."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "BookStack Sync-innstillinger",
+        "data": {
+          "book_id": "Målbok",
+          "sync_interval": "Synkroniseringsintervall",
+          "excluded_areas": "Ekskluderte områder (vil ikke synkroniseres)",
+          "output_language": "Språk for BookStack-sider"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "Hver time",
+        "daily": "Daglig",
+        "manual": "Bare manuelt (tjenestekall)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Som Home Assistant (auto)",
+        "de": "Tysk",
+        "en": "Engelsk"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Synkroniser nå",
+      "description": "Starter en synkronisering umiddelbart uten å vente på intervallet."
+    },
+    "preview": {
+      "name": "Forhåndsvisning av synkronisering",
+      "description": "Logger hvilke sider som ville bli opprettet/oppdatert uten å skrive noe til BookStack."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Synkroniseringsstatus",
+        "state": {
+          "ok": "OK",
+          "error": "Feil",
+          "never_run": "Aldri kjørt",
+          "syncing": "Synkronisering pågår"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Synkroniser nå"
+      },
+      "preview": {
+        "name": "Forhåndsvisning av synkronisering (tørrkjøring)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack er utilgjengelig",
+      "description": "BookStack Sync-integrasjonen kunne ikke nå BookStack-instansen i {count} påfølgende synkroniseringer. Vanlige årsaker: BookStack-containeren er stoppet, nettverksproblem eller en revers-proxy avviser tilkoblinger. Neste vellykkede synkronisering løser dette varselet automatisk."
+    },
+    "page_tampered": {
+      "title": "En sides AUTO-blokk er redigert manuelt",
+      "description": "Siden «{page_title}» i BookStack har en AUTO-blokk som ble redigert utenfor Home Assistant. Integrasjonen hoppet over denne siden under synkronisering for ikke å overskrive endringene dine. Flytt notatene dine til MANUAL-blokken eller angre endringen i AUTO-blokken slik at neste synkronisering kan oppdatere siden igjen."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "BookStack-instans utilgjengelig (se Home Assistant-loggen for detaljer)."
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack avviste API-tokenet. Forny tokenet i BookStack og bruk Reauth-flyten."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/nl.json
+++ b/custom_components/bookstack_sync/translations/nl.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "BookStack-verbinding",
+        "description": "Verbind Home Assistant met je BookStack-instantie.\n\nGa in BookStack naar *Mijn account → API-tokens*, maak een token aan en plak het ID en het geheim hier.\n\nDocumentatie: {documentation_url}",
+        "data": {
+          "base_url": "BookStack-URL",
+          "token_id": "API-token-ID",
+          "token_secret": "API-token-geheim",
+          "verify_ssl": "TLS-certificaat verifiëren (uitschakelen voor zelfondertekende)"
+        }
+      },
+      "book": {
+        "title": "Kies doelboek",
+        "description": "Naar welk boek moet Home Assistant synchroniseren? Handmatig toegevoegde inhoud op pagina's blijft behouden.",
+        "data": {
+          "book_id": "Doelboek",
+          "sync_interval": "Synchronisatie-interval"
+        }
+      },
+      "reauth_confirm": {
+        "title": "BookStack-token vernieuwen",
+        "description": "BookStack heeft het API-token voor {base_url} geweigerd. Maak een nieuw token aan in BookStack en plak ID en geheim hier — URL en doelboek blijven hetzelfde.",
+        "data": {
+          "token_id": "API-token-ID",
+          "token_secret": "API-token-geheim"
+        }
+      },
+      "reconfigure": {
+        "title": "BookStack-verbinding aanpassen",
+        "description": "Wijzig URL, token of TLS-instelling van deze verbinding. Het doelboek en alle pagina-toewijzingen blijven behouden. De URL moet naar dezelfde BookStack-instantie wijzen als voorheen.",
+        "data": {
+          "base_url": "BookStack-URL",
+          "token_id": "API-token-ID",
+          "token_secret": "API-token-geheim",
+          "verify_ssl": "TLS-certificaat verifiëren (uitschakelen voor zelfondertekende)"
+        }
+      }
+    },
+    "error": {
+      "auth": "API-token geweigerd of machtigingen ontbreken.",
+      "connection": "Kan BookStack niet bereiken.",
+      "no_books": "Geen boek gevonden in deze BookStack-instantie. Maak eerst een doelboek aan.",
+      "unknown": "Onverwachte fout — controleer het Home Assistant-logboek.",
+      "base_url_invalid_scheme": "URL moet beginnen met http:// of https://.",
+      "base_url_missing_host": "URL is onvolledig — hostnaam ontbreekt."
+    },
+    "abort": {
+      "already_configured": "Deze BookStack-instantie is al geconfigureerd.",
+      "reauth_successful": "Token vernieuwd — BookStack-verbinding hersteld.",
+      "reconfigure_successful": "Verbinding bijgewerkt — BookStack Sync is opnieuw geconfigureerd.",
+      "url_mismatch": "De nieuwe URL wijst naar een andere BookStack-instantie. Verwijder de oorspronkelijke vermelding en voeg een nieuwe toe."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "BookStack Sync-instellingen",
+        "data": {
+          "book_id": "Doelboek",
+          "sync_interval": "Synchronisatie-interval",
+          "excluded_areas": "Uitgesloten gebieden (worden niet gesynchroniseerd)",
+          "output_language": "Taal van BookStack-pagina's"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "Elk uur",
+        "daily": "Dagelijks",
+        "manual": "Alleen handmatig (service-aanroep)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Zoals Home Assistant (auto)",
+        "de": "Duits",
+        "en": "Engels"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Nu synchroniseren",
+      "description": "Start direct een synchronisatie zonder te wachten op het interval."
+    },
+    "preview": {
+      "name": "Synchronisatievoorbeeld",
+      "description": "Logt welke pagina's zouden worden aangemaakt/bijgewerkt zonder iets naar BookStack te schrijven."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Synchronisatiestatus",
+        "state": {
+          "ok": "OK",
+          "error": "Fout",
+          "never_run": "Nog niet uitgevoerd",
+          "syncing": "Synchronisatie bezig"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Nu synchroniseren"
+      },
+      "preview": {
+        "name": "Synchronisatievoorbeeld (proefuitvoering)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack is onbereikbaar",
+      "description": "De BookStack Sync-integratie kon de BookStack-instantie {count} opeenvolgende synchronisaties niet bereiken. Veelvoorkomende oorzaken: de BookStack-container is gestopt, een netwerkprobleem of een reverse proxy weigert verbindingen. De volgende geslaagde synchronisatie lost deze melding automatisch op."
+    },
+    "page_tampered": {
+      "title": "Het AUTO-blok van een pagina is handmatig bewerkt",
+      "description": "De pagina „{page_title}\" in BookStack heeft een AUTO-blok dat buiten Home Assistant is bewerkt. De integratie heeft deze pagina overgeslagen tijdens de synchronisatie om je wijzigingen niet te overschrijven. Verplaats je notities naar het MANUAL-blok of maak de wijziging in het AUTO-blok ongedaan zodat de volgende synchronisatie de pagina opnieuw kan bijwerken."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "BookStack-instantie onbereikbaar (zie Home Assistant-logboek voor details)."
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack heeft het API-token geweigerd. Vernieuw het token in BookStack en gebruik de Reauth-flow."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/pl.json
+++ b/custom_components/bookstack_sync/translations/pl.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Połączenie z BookStack",
+        "description": "Połącz Home Assistant ze swoją instancją BookStack.\n\nW BookStack przejdź do *Moje konto → Tokeny API*, utwórz token i wklej tutaj identyfikator i sekret.\n\nDokumentacja: {documentation_url}",
+        "data": {
+          "base_url": "Adres URL BookStack",
+          "token_id": "Identyfikator tokenu API",
+          "token_secret": "Sekret tokenu API",
+          "verify_ssl": "Weryfikuj certyfikat TLS (wyłącz dla samopodpisanych)"
+        }
+      },
+      "book": {
+        "title": "Wybierz książkę docelową",
+        "description": "Do której książki Home Assistant ma synchronizować? Ręcznie dodana zawartość na stronach zostaje zachowana.",
+        "data": {
+          "book_id": "Książka docelowa",
+          "sync_interval": "Interwał synchronizacji"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Odnów token BookStack",
+        "description": "BookStack odrzucił token API dla {base_url}. Utwórz nowy token w BookStack i wklej tutaj identyfikator i sekret — adres URL i książka docelowa pozostają bez zmian.",
+        "data": {
+          "token_id": "Identyfikator tokenu API",
+          "token_secret": "Sekret tokenu API"
+        }
+      },
+      "reconfigure": {
+        "title": "Dostosuj połączenie z BookStack",
+        "description": "Zmień adres URL, token lub ustawienie TLS tego połączenia. Książka docelowa i wszystkie powiązania stron zostają zachowane. Adres URL musi wskazywać tę samą instancję BookStack co poprzednio.",
+        "data": {
+          "base_url": "Adres URL BookStack",
+          "token_id": "Identyfikator tokenu API",
+          "token_secret": "Sekret tokenu API",
+          "verify_ssl": "Weryfikuj certyfikat TLS (wyłącz dla samopodpisanych)"
+        }
+      }
+    },
+    "error": {
+      "auth": "Token API odrzucony lub brakuje uprawnień.",
+      "connection": "Nie można połączyć się z BookStack.",
+      "no_books": "W tej instancji BookStack nie znaleziono żadnej książki. Najpierw utwórz książkę docelową.",
+      "unknown": "Nieoczekiwany błąd — sprawdź dziennik Home Assistant.",
+      "base_url_invalid_scheme": "Adres URL musi zaczynać się od http:// lub https://.",
+      "base_url_missing_host": "Adres URL jest niekompletny — brakuje nazwy hosta."
+    },
+    "abort": {
+      "already_configured": "Ta instancja BookStack jest już skonfigurowana.",
+      "reauth_successful": "Token odnowiony — połączenie z BookStack przywrócone.",
+      "reconfigure_successful": "Połączenie zaktualizowane — BookStack Sync został zrekonfigurowany.",
+      "url_mismatch": "Nowy adres URL wskazuje inną instancję BookStack. Usuń pierwotny wpis i dodaj nowy."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Ustawienia BookStack Sync",
+        "data": {
+          "book_id": "Książka docelowa",
+          "sync_interval": "Interwał synchronizacji",
+          "excluded_areas": "Wykluczone obszary (nie będą synchronizowane)",
+          "output_language": "Język stron BookStack"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "Co godzinę",
+        "daily": "Codziennie",
+        "manual": "Tylko ręcznie (wywołanie usługi)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Jak Home Assistant (auto)",
+        "de": "Niemiecki",
+        "en": "Angielski"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Synchronizuj teraz",
+      "description": "Uruchamia synchronizację natychmiast, bez czekania na interwał."
+    },
+    "preview": {
+      "name": "Podgląd synchronizacji",
+      "description": "Rejestruje, które strony zostałyby utworzone/zaktualizowane, bez zapisywania czegokolwiek do BookStack."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Status synchronizacji",
+        "state": {
+          "ok": "OK",
+          "error": "Błąd",
+          "never_run": "Jeszcze nie uruchomione",
+          "syncing": "Synchronizacja w toku"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Synchronizuj teraz"
+      },
+      "preview": {
+        "name": "Podgląd synchronizacji (próbne uruchomienie)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack jest nieosiągalny",
+      "description": "Integracja BookStack Sync nie mogła osiągnąć instancji BookStack przez {count} kolejnych synchronizacji. Częste przyczyny: kontener BookStack jest zatrzymany, problem sieciowy lub reverse proxy odrzuca połączenia. Następna pomyślna synchronizacja automatycznie rozwiąże to powiadomienie."
+    },
+    "page_tampered": {
+      "title": "Blok AUTO strony został zedytowany ręcznie",
+      "description": "Strona „{page_title}\" w BookStack zawiera blok AUTO, który został zedytowany poza Home Assistantem. Integracja pominęła tę stronę podczas synchronizacji, aby nie nadpisać Twoich zmian. Przenieś notatki do bloku MANUAL lub cofnij zmianę w bloku AUTO, aby kolejna synchronizacja mogła ponownie zaktualizować stronę."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "Instancja BookStack jest nieosiągalna (szczegóły w dzienniku Home Assistant)."
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack odrzucił token API. Odnów token w BookStack i użyj procesu Reauth."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/pt.json
+++ b/custom_components/bookstack_sync/translations/pt.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Ligação BookStack",
+        "description": "Ligue o Home Assistant à sua instância BookStack.\n\nNo BookStack vá a *A minha conta → Tokens API*, crie um token e cole aqui o ID e o segredo.\n\nDocumentação: {documentation_url}",
+        "data": {
+          "base_url": "URL BookStack",
+          "token_id": "ID do token API",
+          "token_secret": "Segredo do token API",
+          "verify_ssl": "Verificar certificado TLS (desative para autoassinados)"
+        }
+      },
+      "book": {
+        "title": "Escolher livro de destino",
+        "description": "Para que livro deve o Home Assistant sincronizar? O conteúdo adicionado manualmente nas páginas é mantido.",
+        "data": {
+          "book_id": "Livro de destino",
+          "sync_interval": "Intervalo de sincronização"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Renovar token BookStack",
+        "description": "O BookStack rejeitou o token API para {base_url}. Crie um novo token no BookStack e cole aqui o ID e o segredo — o URL e o livro de destino permanecem inalterados.",
+        "data": {
+          "token_id": "ID do token API",
+          "token_secret": "Segredo do token API"
+        }
+      },
+      "reconfigure": {
+        "title": "Ajustar ligação BookStack",
+        "description": "Altere o URL, o token ou a definição TLS desta ligação. O livro de destino e todas as associações de páginas são mantidos. O URL deve apontar para a mesma instância BookStack que antes.",
+        "data": {
+          "base_url": "URL BookStack",
+          "token_id": "ID do token API",
+          "token_secret": "Segredo do token API",
+          "verify_ssl": "Verificar certificado TLS (desative para autoassinados)"
+        }
+      }
+    },
+    "error": {
+      "auth": "Token API rejeitado ou faltam permissões.",
+      "connection": "Não foi possível alcançar o BookStack.",
+      "no_books": "Nenhum livro encontrado nesta instância BookStack. Crie primeiro um livro de destino.",
+      "unknown": "Erro inesperado — verifique o registo do Home Assistant.",
+      "base_url_invalid_scheme": "O URL deve começar por http:// ou https://.",
+      "base_url_missing_host": "O URL está incompleto — falta o nome do anfitrião."
+    },
+    "abort": {
+      "already_configured": "Esta instância BookStack já está configurada.",
+      "reauth_successful": "Token renovado — ligação BookStack restaurada.",
+      "reconfigure_successful": "Ligação atualizada — o BookStack Sync foi reconfigurado.",
+      "url_mismatch": "O novo URL aponta para outra instância BookStack. Remova a entrada original e adicione uma nova."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Definições do BookStack Sync",
+        "data": {
+          "book_id": "Livro de destino",
+          "sync_interval": "Intervalo de sincronização",
+          "excluded_areas": "Áreas excluídas (não serão sincronizadas)",
+          "output_language": "Idioma das páginas BookStack"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "A cada hora",
+        "daily": "Diariamente",
+        "manual": "Apenas manual (chamada de serviço)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Como o Home Assistant (auto)",
+        "de": "Alemão",
+        "en": "Inglês"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Sincronizar agora",
+      "description": "Inicia uma sincronização imediatamente sem aguardar o intervalo."
+    },
+    "preview": {
+      "name": "Pré-visualização da sincronização",
+      "description": "Regista que páginas seriam criadas/atualizadas sem escrever nada no BookStack."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Estado da sincronização",
+        "state": {
+          "ok": "OK",
+          "error": "Erro",
+          "never_run": "Ainda não executado",
+          "syncing": "Sincronização em curso"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Sincronizar agora"
+      },
+      "preview": {
+        "name": "Pré-visualização da sincronização (execução de teste)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack está inacessível",
+      "description": "A integração BookStack Sync não conseguiu alcançar a instância BookStack durante {count} sincronizações consecutivas. Causas comuns: o contentor BookStack está parado, problema de rede ou um proxy inverso recusa as ligações. A próxima sincronização bem-sucedida resolve esta notificação automaticamente."
+    },
+    "page_tampered": {
+      "title": "O bloco AUTO de uma página foi editado manualmente",
+      "description": "A página «{page_title}» no BookStack tem um bloco AUTO que foi editado fora do Home Assistant. A integração ignorou esta página durante a sincronização para não sobrescrever as suas alterações. Mova as suas notas para o bloco MANUAL ou anule a alteração no bloco AUTO para que a próxima sincronização possa atualizar novamente a página."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "Instância BookStack inacessível (consulte o registo do Home Assistant para detalhes)."
+    },
+    "bookstack_auth_failed": {
+      "message": "O BookStack rejeitou o token API. Renove o token no BookStack e use o fluxo Reauth."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/ro.json
+++ b/custom_components/bookstack_sync/translations/ro.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Conexiune BookStack",
+        "description": "Conectați Home Assistant la instanța dvs. BookStack.\n\nÎn BookStack accesați *Contul meu → Tokenuri API*, creați un token și lipiți aici ID-ul și secretul.\n\nDocumentație: {documentation_url}",
+        "data": {
+          "base_url": "URL BookStack",
+          "token_id": "ID token API",
+          "token_secret": "Secret token API",
+          "verify_ssl": "Verifică certificatul TLS (dezactivați pentru autosemnate)"
+        }
+      },
+      "book": {
+        "title": "Alegeți cartea țintă",
+        "description": "În ce carte ar trebui să sincronizeze Home Assistant? Conținutul adăugat manual pe pagini este păstrat.",
+        "data": {
+          "book_id": "Cartea țintă",
+          "sync_interval": "Interval de sincronizare"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Reînnoiți tokenul BookStack",
+        "description": "BookStack a respins tokenul API pentru {base_url}. Creați un token nou în BookStack și lipiți aici ID-ul și secretul — URL-ul și cartea țintă rămân neschimbate.",
+        "data": {
+          "token_id": "ID token API",
+          "token_secret": "Secret token API"
+        }
+      },
+      "reconfigure": {
+        "title": "Ajustați conexiunea BookStack",
+        "description": "Modificați URL-ul, tokenul sau setarea TLS a acestei conexiuni. Cartea țintă și toate asocierile de pagini sunt păstrate. URL-ul trebuie să indice aceeași instanță BookStack ca înainte.",
+        "data": {
+          "base_url": "URL BookStack",
+          "token_id": "ID token API",
+          "token_secret": "Secret token API",
+          "verify_ssl": "Verifică certificatul TLS (dezactivați pentru autosemnate)"
+        }
+      }
+    },
+    "error": {
+      "auth": "Token API respins sau lipsesc permisiuni.",
+      "connection": "Nu se poate accesa BookStack.",
+      "no_books": "Nu s-a găsit nicio carte în această instanță BookStack. Creați mai întâi o carte țintă.",
+      "unknown": "Eroare neașteptată — verificați jurnalul Home Assistant.",
+      "base_url_invalid_scheme": "URL-ul trebuie să înceapă cu http:// sau https://.",
+      "base_url_missing_host": "URL-ul este incomplet — lipsește numele gazdei."
+    },
+    "abort": {
+      "already_configured": "Această instanță BookStack este deja configurată.",
+      "reauth_successful": "Token reînnoit — conexiunea BookStack restabilită.",
+      "reconfigure_successful": "Conexiune actualizată — BookStack Sync a fost reconfigurat.",
+      "url_mismatch": "Noul URL indică o altă instanță BookStack. Eliminați intrarea originală și adăugați una nouă."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Setări BookStack Sync",
+        "data": {
+          "book_id": "Cartea țintă",
+          "sync_interval": "Interval de sincronizare",
+          "excluded_areas": "Zone excluse (nu vor fi sincronizate)",
+          "output_language": "Limba paginilor BookStack"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "În fiecare oră",
+        "daily": "Zilnic",
+        "manual": "Doar manual (apel serviciu)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Ca Home Assistant (auto)",
+        "de": "Germană",
+        "en": "Engleză"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Sincronizează acum",
+      "description": "Pornește o sincronizare imediat, fără a aștepta intervalul."
+    },
+    "preview": {
+      "name": "Previzualizare sincronizare",
+      "description": "Înregistrează ce pagini ar fi create/actualizate fără a scrie nimic în BookStack."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Stare sincronizare",
+        "state": {
+          "ok": "OK",
+          "error": "Eroare",
+          "never_run": "Încă nu a rulat",
+          "syncing": "Sincronizare în desfășurare"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Sincronizează acum"
+      },
+      "preview": {
+        "name": "Previzualizare sincronizare (rulare de probă)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack este inaccesibil",
+      "description": "Integrarea BookStack Sync nu a putut accesa instanța BookStack timp de {count} sincronizări consecutive. Cauze frecvente: containerul BookStack este oprit, problemă de rețea sau un proxy invers refuză conexiunile. Următoarea sincronizare reușită va rezolva automat această notificare."
+    },
+    "page_tampered": {
+      "title": "Blocul AUTO al unei pagini a fost editat manual",
+      "description": "Pagina „{page_title}\" din BookStack are un bloc AUTO care a fost editat în afara Home Assistant. Integrarea a omis această pagină în timpul sincronizării pentru a nu suprascrie modificările dvs. Mutați notele în blocul MANUAL sau anulați modificarea din blocul AUTO pentru ca următoarea sincronizare să poată actualiza din nou pagina."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "Instanța BookStack inaccesibilă (consultați jurnalul Home Assistant pentru detalii)."
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack a respins tokenul API. Reînnoiți tokenul în BookStack și utilizați fluxul Reauth."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/sk.json
+++ b/custom_components/bookstack_sync/translations/sk.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Pripojenie BookStack",
+        "description": "Pripojte Home Assistant k vašej inštancii BookStack.\n\nV BookStacku prejdite na *Môj účet → API tokeny*, vytvorte token a vložte tu ID a tajný kľúč.\n\nDokumentácia: {documentation_url}",
+        "data": {
+          "base_url": "URL adresa BookStack",
+          "token_id": "ID API tokenu",
+          "token_secret": "Tajný kľúč API tokenu",
+          "verify_ssl": "Overiť TLS certifikát (zakážte pre samopodpísané)"
+        }
+      },
+      "book": {
+        "title": "Vyberte cieľovú knihu",
+        "description": "Do ktorej knihy má Home Assistant synchronizovať? Manuálne pridaný obsah na stránkach zostane zachovaný.",
+        "data": {
+          "book_id": "Cieľová kniha",
+          "sync_interval": "Interval synchronizácie"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Obnoviť BookStack token",
+        "description": "BookStack zamietol API token pre {base_url}. Vytvorte nový token v BookStacku a vložte tu ID a tajný kľúč — URL a cieľová kniha zostávajú rovnaké.",
+        "data": {
+          "token_id": "ID API tokenu",
+          "token_secret": "Tajný kľúč API tokenu"
+        }
+      },
+      "reconfigure": {
+        "title": "Upraviť pripojenie BookStack",
+        "description": "Zmeňte URL, token alebo nastavenie TLS tohto pripojenia. Cieľová kniha a všetky priradenia stránok zostanú zachované. URL musí ukazovať na tú istú inštanciu BookStack ako predtým.",
+        "data": {
+          "base_url": "URL adresa BookStack",
+          "token_id": "ID API tokenu",
+          "token_secret": "Tajný kľúč API tokenu",
+          "verify_ssl": "Overiť TLS certifikát (zakážte pre samopodpísané)"
+        }
+      }
+    },
+    "error": {
+      "auth": "API token zamietnutý alebo chýbajú oprávnenia.",
+      "connection": "BookStack sa nedá dosiahnuť.",
+      "no_books": "V tejto inštancii BookStack sa nenašla žiadna kniha. Najprv vytvorte cieľovú knihu.",
+      "unknown": "Neočakávaná chyba — skontrolujte protokol Home Assistant.",
+      "base_url_invalid_scheme": "URL musí začínať http:// alebo https://.",
+      "base_url_missing_host": "URL je neúplné — chýba názov hostiteľa."
+    },
+    "abort": {
+      "already_configured": "Táto inštancia BookStack je už nakonfigurovaná.",
+      "reauth_successful": "Token obnovený — pripojenie BookStack obnovené.",
+      "reconfigure_successful": "Pripojenie aktualizované — BookStack Sync bol prekonfigurovaný.",
+      "url_mismatch": "Nová URL ukazuje na inú inštanciu BookStack. Odstráňte pôvodnú položku a pridajte novú."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Nastavenia BookStack Sync",
+        "data": {
+          "book_id": "Cieľová kniha",
+          "sync_interval": "Interval synchronizácie",
+          "excluded_areas": "Vylúčené oblasti (nebudú synchronizované)",
+          "output_language": "Jazyk stránok BookStack"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "Každú hodinu",
+        "daily": "Denne",
+        "manual": "Iba manuálne (volanie služby)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Ako Home Assistant (auto)",
+        "de": "Nemecky",
+        "en": "Anglicky"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Synchronizovať teraz",
+      "description": "Spustí synchronizáciu okamžite bez čakania na interval."
+    },
+    "preview": {
+      "name": "Náhľad synchronizácie",
+      "description": "Zaznamená, ktoré stránky by sa vytvorili/aktualizovali, bez zapisovania čohokoľvek do BookStack."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Stav synchronizácie",
+        "state": {
+          "ok": "OK",
+          "error": "Chyba",
+          "never_run": "Ešte nebolo spustené",
+          "syncing": "Synchronizácia prebieha"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Synchronizovať teraz"
+      },
+      "preview": {
+        "name": "Náhľad synchronizácie (skúšobný beh)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack je nedostupný",
+      "description": "Integrácia BookStack Sync nedokázala dosiahnuť inštanciu BookStack počas {count} po sebe nasledujúcich synchronizácií. Bežné príčiny: kontajner BookStack je zastavený, problém so sieťou alebo reverzný proxy odmieta pripojenia. Ďalšia úspešná synchronizácia toto upozornenie automaticky vyrieši."
+    },
+    "page_tampered": {
+      "title": "Blok AUTO stránky bol upravený manuálne",
+      "description": "Stránka „{page_title}\" v BookStacku má blok AUTO, ktorý bol upravený mimo Home Assistant. Integrácia túto stránku počas synchronizácie preskočila, aby neprepísala vaše zmeny. Presuňte poznámky do bloku MANUAL alebo zrušte zmenu v bloku AUTO, aby ďalšia synchronizácia mohla stránku znova aktualizovať."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "Inštancia BookStack je nedostupná (podrobnosti nájdete v protokole Home Assistant)."
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack zamietol API token. Obnovte token v BookStacku a použite proces Reauth."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/sl.json
+++ b/custom_components/bookstack_sync/translations/sl.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Povezava BookStack",
+        "description": "Povežite Home Assistant s svojim primerkom BookStack.\n\nV BookStacku pojdite na *Moj račun → API žetoni*, ustvarite žeton in tukaj prilepite ID in skrivnost.\n\nDokumentacija: {documentation_url}",
+        "data": {
+          "base_url": "URL BookStack",
+          "token_id": "ID API žetona",
+          "token_secret": "Skrivnost API žetona",
+          "verify_ssl": "Preveri TLS potrdilo (onemogočite za samopodpisana)"
+        }
+      },
+      "book": {
+        "title": "Izberite ciljno knjigo",
+        "description": "V katero knjigo naj Home Assistant sinhronizira? Ročno dodana vsebina na straneh se ohrani.",
+        "data": {
+          "book_id": "Ciljna knjiga",
+          "sync_interval": "Interval sinhronizacije"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Obnovi žeton BookStack",
+        "description": "BookStack je zavrnil API žeton za {base_url}. Ustvarite nov žeton v BookStacku in tukaj prilepite ID in skrivnost — URL in ciljna knjiga ostaneta nespremenjena.",
+        "data": {
+          "token_id": "ID API žetona",
+          "token_secret": "Skrivnost API žetona"
+        }
+      },
+      "reconfigure": {
+        "title": "Prilagodi povezavo BookStack",
+        "description": "Spremenite URL, žeton ali nastavitev TLS te povezave. Ciljna knjiga in vse povezave strani se ohranijo. URL mora kazati na isti primerek BookStack kot prej.",
+        "data": {
+          "base_url": "URL BookStack",
+          "token_id": "ID API žetona",
+          "token_secret": "Skrivnost API žetona",
+          "verify_ssl": "Preveri TLS potrdilo (onemogočite za samopodpisana)"
+        }
+      }
+    },
+    "error": {
+      "auth": "API žeton zavrnjen ali manjkajo dovoljenja.",
+      "connection": "BookStacka ni mogoče doseči.",
+      "no_books": "V tem primerku BookStack ni najdene nobene knjige. Najprej ustvarite ciljno knjigo.",
+      "unknown": "Nepričakovana napaka — preverite dnevnik Home Assistant.",
+      "base_url_invalid_scheme": "URL se mora začeti s http:// ali https://.",
+      "base_url_missing_host": "URL je nepopoln — manjka ime gostitelja."
+    },
+    "abort": {
+      "already_configured": "Ta primerek BookStack je že konfiguriran.",
+      "reauth_successful": "Žeton obnovljen — povezava BookStack obnovljena.",
+      "reconfigure_successful": "Povezava posodobljena — BookStack Sync je bil ponovno konfiguriran.",
+      "url_mismatch": "Novi URL kaže na drug primerek BookStack. Odstranite izvirni vnos in dodajte novega."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Nastavitve BookStack Sync",
+        "data": {
+          "book_id": "Ciljna knjiga",
+          "sync_interval": "Interval sinhronizacije",
+          "excluded_areas": "Izključena območja (ne bodo sinhronizirana)",
+          "output_language": "Jezik strani BookStack"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "Vsako uro",
+        "daily": "Dnevno",
+        "manual": "Samo ročno (klic storitve)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Kot Home Assistant (samodejno)",
+        "de": "Nemško",
+        "en": "Angleško"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Sinhroniziraj zdaj",
+      "description": "Takoj zažene sinhronizacijo brez čakanja na interval."
+    },
+    "preview": {
+      "name": "Predogled sinhronizacije",
+      "description": "Beleži, katere strani bi bile ustvarjene/posodobljene, ne da bi karkoli zapisal v BookStack."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Stanje sinhronizacije",
+        "state": {
+          "ok": "OK",
+          "error": "Napaka",
+          "never_run": "Še ni zagnano",
+          "syncing": "Sinhronizacija poteka"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Sinhroniziraj zdaj"
+      },
+      "preview": {
+        "name": "Predogled sinhronizacije (preizkusni zagon)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack ni dosegljiv",
+      "description": "Integracija BookStack Sync ni mogla doseči primerka BookStack v {count} zaporednih sinhronizacijah. Pogosti vzroki: vsebnik BookStack je ustavljen, težava z omrežjem ali povratni posredniški strežnik zavrača povezave. Naslednja uspešna sinhronizacija bo to obvestilo samodejno odpravila."
+    },
+    "page_tampered": {
+      "title": "Blok AUTO strani je bil ročno urejen",
+      "description": "Stran „{page_title}\" v BookStacku ima blok AUTO, ki je bil urejen zunaj Home Assistanta. Integracija je to stran med sinhronizacijo preskočila, da ne bi prepisala vaših sprememb. Premaknite svoje opombe v blok MANUAL ali razveljavite spremembo v bloku AUTO, da bo naslednja sinhronizacija lahko stran znova posodobila."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "Primerek BookStack ni dosegljiv (za podrobnosti glejte dnevnik Home Assistant)."
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack je zavrnil API žeton. Obnovite žeton v BookStacku in uporabite postopek Reauth."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/sv.json
+++ b/custom_components/bookstack_sync/translations/sv.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "BookStack-anslutning",
+        "description": "Anslut Home Assistant till din BookStack-instans.\n\nI BookStack går du till *Mitt konto → API-tokens*, skapar en token och klistrar in ID och hemlighet här.\n\nDokumentation: {documentation_url}",
+        "data": {
+          "base_url": "BookStack-URL",
+          "token_id": "API-token-ID",
+          "token_secret": "API-token-hemlighet",
+          "verify_ssl": "Verifiera TLS-certifikat (inaktivera för självsignerade)"
+        }
+      },
+      "book": {
+        "title": "Välj målbok",
+        "description": "Vilken bok ska Home Assistant synkronisera till? Manuellt tillagt innehåll på sidorna bevaras.",
+        "data": {
+          "book_id": "Målbok",
+          "sync_interval": "Synkroniseringsintervall"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Förnya BookStack-token",
+        "description": "BookStack avvisade API-tokenet för {base_url}. Skapa en ny token i BookStack och klistra in ID och hemlighet här — URL och målbok förblir oförändrade.",
+        "data": {
+          "token_id": "API-token-ID",
+          "token_secret": "API-token-hemlighet"
+        }
+      },
+      "reconfigure": {
+        "title": "Justera BookStack-anslutning",
+        "description": "Ändra URL, token eller TLS-inställning för denna anslutning. Målboken och alla sidkopplingar bevaras. URL:en måste peka på samma BookStack-instans som tidigare.",
+        "data": {
+          "base_url": "BookStack-URL",
+          "token_id": "API-token-ID",
+          "token_secret": "API-token-hemlighet",
+          "verify_ssl": "Verifiera TLS-certifikat (inaktivera för självsignerade)"
+        }
+      }
+    },
+    "error": {
+      "auth": "API-token avvisad eller behörigheter saknas.",
+      "connection": "Kan inte nå BookStack.",
+      "no_books": "Ingen bok hittades i denna BookStack-instans. Skapa en målbok först.",
+      "unknown": "Oväntat fel — kontrollera Home Assistant-loggen.",
+      "base_url_invalid_scheme": "URL:en måste börja med http:// eller https://.",
+      "base_url_missing_host": "URL:en är ofullständig — värdnamnet saknas."
+    },
+    "abort": {
+      "already_configured": "Denna BookStack-instans är redan konfigurerad.",
+      "reauth_successful": "Token förnyad — BookStack-anslutning återställd.",
+      "reconfigure_successful": "Anslutning uppdaterad — BookStack Sync har konfigurerats om.",
+      "url_mismatch": "Den nya URL:en pekar på en annan BookStack-instans. Ta bort den ursprungliga posten och lägg till en ny."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "BookStack Sync-inställningar",
+        "data": {
+          "book_id": "Målbok",
+          "sync_interval": "Synkroniseringsintervall",
+          "excluded_areas": "Uteslutna områden (kommer inte synkroniseras)",
+          "output_language": "Språk för BookStack-sidor"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "Varje timme",
+        "daily": "Dagligen",
+        "manual": "Endast manuellt (tjänsteanrop)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Som Home Assistant (auto)",
+        "de": "Tyska",
+        "en": "Engelska"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Synkronisera nu",
+      "description": "Startar en synkronisering omedelbart utan att vänta på intervallet."
+    },
+    "preview": {
+      "name": "Förhandsgranskning av synkronisering",
+      "description": "Loggar vilka sidor som skulle skapas/uppdateras utan att skriva något till BookStack."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Synkroniseringsstatus",
+        "state": {
+          "ok": "OK",
+          "error": "Fel",
+          "never_run": "Aldrig körd",
+          "syncing": "Synkronisering pågår"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Synkronisera nu"
+      },
+      "preview": {
+        "name": "Förhandsgranskning av synkronisering (torrkörning)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack är onåbar",
+      "description": "BookStack Sync-integrationen kunde inte nå BookStack-instansen under {count} på varandra följande synkroniseringar. Vanliga orsaker: BookStack-containern är stoppad, nätverksproblem eller en omvänd proxy avvisar anslutningar. Nästa lyckade synkronisering löser detta meddelande automatiskt."
+    },
+    "page_tampered": {
+      "title": "En sidas AUTO-block har redigerats manuellt",
+      "description": "Sidan ”{page_title}” i BookStack har ett AUTO-block som har redigerats utanför Home Assistant. Integrationen hoppade över denna sida vid synkronisering för att inte skriva över dina ändringar. Flytta dina anteckningar till MANUAL-blocket eller ångra ändringen i AUTO-blocket så att nästa synkronisering kan uppdatera sidan igen."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "BookStack-instans onåbar (se Home Assistant-loggen för detaljer)."
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack avvisade API-tokenet. Förnya tokenet i BookStack och använd Reauth-flödet."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/th.json
+++ b/custom_components/bookstack_sync/translations/th.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "การเชื่อมต่อ BookStack",
+        "description": "เชื่อมต่อ Home Assistant เข้ากับอินสแตนซ์ BookStack ของคุณ\n\nใน BookStack ไปที่ *บัญชีของฉัน → API tokens* สร้าง token แล้ววาง ID และ secret ที่นี่\n\nเอกสารประกอบ: {documentation_url}",
+        "data": {
+          "base_url": "URL ของ BookStack",
+          "token_id": "API token ID",
+          "token_secret": "API token secret",
+          "verify_ssl": "ตรวจสอบใบรับรอง TLS (ปิดสำหรับใบรับรองที่ลงนามด้วยตนเอง)"
+        }
+      },
+      "book": {
+        "title": "เลือกหนังสือปลายทาง",
+        "description": "Home Assistant ควรซิงค์ไปยังหนังสือใด เนื้อหาที่เพิ่มด้วยตนเองในหน้าจะถูกเก็บรักษาไว้",
+        "data": {
+          "book_id": "หนังสือปลายทาง",
+          "sync_interval": "ช่วงเวลาการซิงค์"
+        }
+      },
+      "reauth_confirm": {
+        "title": "ต่ออายุ token ของ BookStack",
+        "description": "BookStack ปฏิเสธ API token สำหรับ {base_url} สร้าง token ใหม่ใน BookStack แล้ววาง ID และ secret ที่นี่ — URL และหนังสือปลายทางจะยังคงเหมือนเดิม",
+        "data": {
+          "token_id": "API token ID",
+          "token_secret": "API token secret"
+        }
+      },
+      "reconfigure": {
+        "title": "ปรับการเชื่อมต่อ BookStack",
+        "description": "เปลี่ยน URL, token หรือการตั้งค่า TLS ของการเชื่อมต่อนี้ หนังสือปลายทางและการแมปหน้าทั้งหมดจะถูกเก็บไว้ URL ต้องชี้ไปยังอินสแตนซ์ BookStack เดิมเช่นเดียวกับก่อนหน้านี้",
+        "data": {
+          "base_url": "URL ของ BookStack",
+          "token_id": "API token ID",
+          "token_secret": "API token secret",
+          "verify_ssl": "ตรวจสอบใบรับรอง TLS (ปิดสำหรับใบรับรองที่ลงนามด้วยตนเอง)"
+        }
+      }
+    },
+    "error": {
+      "auth": "API token ถูกปฏิเสธหรือสิทธิ์ไม่เพียงพอ",
+      "connection": "ไม่สามารถเข้าถึง BookStack",
+      "no_books": "ไม่พบหนังสือในอินสแตนซ์ BookStack นี้ โปรดสร้างหนังสือปลายทางก่อน",
+      "unknown": "ข้อผิดพลาดที่ไม่คาดคิด — โปรดตรวจสอบบันทึกของ Home Assistant",
+      "base_url_invalid_scheme": "URL ต้องขึ้นต้นด้วย http:// หรือ https://",
+      "base_url_missing_host": "URL ไม่สมบูรณ์ — ขาดชื่อโฮสต์"
+    },
+    "abort": {
+      "already_configured": "อินสแตนซ์ BookStack นี้ได้รับการกำหนดค่าแล้ว",
+      "reauth_successful": "Token ได้รับการต่ออายุ — การเชื่อมต่อ BookStack กลับมาแล้ว",
+      "reconfigure_successful": "การเชื่อมต่อได้รับการอัปเดต — BookStack Sync ถูกกำหนดค่าใหม่แล้ว",
+      "url_mismatch": "URL ใหม่ชี้ไปยังอินสแตนซ์ BookStack อื่น โปรดลบรายการเดิมออกแล้วเพิ่มรายการใหม่"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "การตั้งค่า BookStack Sync",
+        "data": {
+          "book_id": "หนังสือปลายทาง",
+          "sync_interval": "ช่วงเวลาการซิงค์",
+          "excluded_areas": "พื้นที่ที่ยกเว้น (จะไม่ถูกซิงค์)",
+          "output_language": "ภาษาของหน้า BookStack"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "ทุกชั่วโมง",
+        "daily": "รายวัน",
+        "manual": "ด้วยตนเองเท่านั้น (เรียกบริการ)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "เหมือน Home Assistant (อัตโนมัติ)",
+        "de": "เยอรมัน",
+        "en": "อังกฤษ"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "ซิงค์ทันที",
+      "description": "เริ่มการซิงค์ทันทีโดยไม่ต้องรอช่วงเวลา"
+    },
+    "preview": {
+      "name": "ตัวอย่างการซิงค์",
+      "description": "บันทึกว่าหน้าใดจะถูกสร้าง/อัปเดต โดยไม่เขียนอะไรลงใน BookStack"
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "สถานะการซิงค์",
+        "state": {
+          "ok": "OK",
+          "error": "ข้อผิดพลาด",
+          "never_run": "ยังไม่เคยรัน",
+          "syncing": "กำลังซิงค์"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "ซิงค์ทันที"
+      },
+      "preview": {
+        "name": "ตัวอย่างการซิงค์ (รันทดลอง)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "ไม่สามารถเข้าถึง BookStack ได้",
+      "description": "การผสานรวม BookStack Sync ไม่สามารถเข้าถึงอินสแตนซ์ BookStack ได้เป็นเวลา {count} การซิงค์ติดต่อกัน สาเหตุที่พบบ่อย: คอนเทนเนอร์ BookStack หยุดทำงาน ปัญหาเครือข่าย หรือ reverse proxy ปฏิเสธการเชื่อมต่อ การซิงค์ที่สำเร็จครั้งต่อไปจะแก้ไขการแจ้งเตือนนี้โดยอัตโนมัติ"
+    },
+    "page_tampered": {
+      "title": "บล็อก AUTO ของหน้าถูกแก้ไขด้วยตนเอง",
+      "description": "หน้า „{page_title}\" ใน BookStack มีบล็อก AUTO ที่ถูกแก้ไขนอก Home Assistant การผสานรวมข้ามหน้านี้ระหว่างการซิงค์เพื่อไม่ให้เขียนทับการเปลี่ยนแปลงของคุณ ย้ายบันทึกของคุณไปยังบล็อก MANUAL หรือยกเลิกการเปลี่ยนแปลงในบล็อก AUTO เพื่อให้การซิงค์ครั้งถัดไปสามารถอัปเดตหน้าได้อีกครั้ง"
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "ไม่สามารถเข้าถึงอินสแตนซ์ BookStack (ดูรายละเอียดในบันทึกของ Home Assistant)"
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack ปฏิเสธ API token โปรดต่ออายุ token ใน BookStack และใช้กระบวนการ Reauth"
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/uk.json
+++ b/custom_components/bookstack_sync/translations/uk.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "З'єднання BookStack",
+        "description": "Підключіть Home Assistant до вашого екземпляра BookStack.\n\nУ BookStack перейдіть до *Мій акаунт → Токени API*, створіть токен і вставте сюди ID та секрет.\n\nДокументація: {documentation_url}",
+        "data": {
+          "base_url": "URL BookStack",
+          "token_id": "ID токена API",
+          "token_secret": "Секрет токена API",
+          "verify_ssl": "Перевіряти сертифікат TLS (вимкніть для самопідписаних)"
+        }
+      },
+      "book": {
+        "title": "Оберіть цільову книгу",
+        "description": "У яку книгу повинен синхронізувати Home Assistant? Вміст, доданий вручну на сторінках, зберігається.",
+        "data": {
+          "book_id": "Цільова книга",
+          "sync_interval": "Інтервал синхронізації"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Оновити токен BookStack",
+        "description": "BookStack відхилив токен API для {base_url}. Створіть новий токен у BookStack і вставте сюди ID та секрет — URL і цільова книга залишаться незмінними.",
+        "data": {
+          "token_id": "ID токена API",
+          "token_secret": "Секрет токена API"
+        }
+      },
+      "reconfigure": {
+        "title": "Налаштувати з'єднання BookStack",
+        "description": "Змініть URL, токен або налаштування TLS цього з'єднання. Цільова книга та всі прив'язки сторінок зберігаються. URL повинен вказувати на той самий екземпляр BookStack, що й раніше.",
+        "data": {
+          "base_url": "URL BookStack",
+          "token_id": "ID токена API",
+          "token_secret": "Секрет токена API",
+          "verify_ssl": "Перевіряти сертифікат TLS (вимкніть для самопідписаних)"
+        }
+      }
+    },
+    "error": {
+      "auth": "Токен API відхилено або відсутні дозволи.",
+      "connection": "Не вдається досягти BookStack.",
+      "no_books": "У цьому екземплярі BookStack не знайдено жодної книги. Спочатку створіть цільову книгу.",
+      "unknown": "Несподівана помилка — перевірте журнал Home Assistant.",
+      "base_url_invalid_scheme": "URL має починатися з http:// або https://.",
+      "base_url_missing_host": "URL неповний — відсутнє ім'я хоста."
+    },
+    "abort": {
+      "already_configured": "Цей екземпляр BookStack уже налаштовано.",
+      "reauth_successful": "Токен оновлено — з'єднання BookStack відновлено.",
+      "reconfigure_successful": "З'єднання оновлено — BookStack Sync переналаштовано.",
+      "url_mismatch": "Новий URL вказує на інший екземпляр BookStack. Видаліть початковий запис і додайте новий."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Налаштування BookStack Sync",
+        "data": {
+          "book_id": "Цільова книга",
+          "sync_interval": "Інтервал синхронізації",
+          "excluded_areas": "Виключені області (не синхронізуватимуться)",
+          "output_language": "Мова сторінок BookStack"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "Щогодини",
+        "daily": "Щодня",
+        "manual": "Лише вручну (виклик служби)"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "Як Home Assistant (авто)",
+        "de": "Німецька",
+        "en": "Англійська"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "Синхронізувати зараз",
+      "description": "Запускає синхронізацію негайно, не чекаючи інтервалу."
+    },
+    "preview": {
+      "name": "Попередній перегляд синхронізації",
+      "description": "Записує, які сторінки було б створено/оновлено, нічого не записуючи в BookStack."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "Статус синхронізації",
+        "state": {
+          "ok": "OK",
+          "error": "Помилка",
+          "never_run": "Ще не запускалося",
+          "syncing": "Триває синхронізація"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "Синхронізувати зараз"
+      },
+      "preview": {
+        "name": "Попередній перегляд синхронізації (тестовий запуск)"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack недоступний",
+      "description": "Інтеграція BookStack Sync не змогла досягти екземпляра BookStack протягом {count} послідовних синхронізацій. Поширені причини: контейнер BookStack зупинено, проблема з мережею або зворотний проксі відхиляє з'єднання. Наступна успішна синхронізація автоматично вирішить це сповіщення."
+    },
+    "page_tampered": {
+      "title": "Блок AUTO сторінки відредаговано вручну",
+      "description": "Сторінка „{page_title}\" у BookStack має блок AUTO, який було відредаговано поза Home Assistant. Інтеграція пропустила цю сторінку під час синхронізації, щоб не перезаписати ваші зміни. Перенесіть свої нотатки до блоку MANUAL або скасуйте зміну в блоку AUTO, щоб наступна синхронізація могла знову оновити сторінку."
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "Екземпляр BookStack недоступний (детальніше в журналі Home Assistant)."
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack відхилив токен API. Оновіть токен у BookStack і використайте процес Reauth."
+    }
+  }
+}

--- a/custom_components/bookstack_sync/translations/zh-Hans.json
+++ b/custom_components/bookstack_sync/translations/zh-Hans.json
@@ -1,0 +1,134 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "BookStack 连接",
+        "description": "将 Home Assistant 连接到您的 BookStack 实例。\n\n在 BookStack 中转到 *我的账户 → API 令牌*，创建令牌并将 ID 和密钥粘贴到此处。\n\n文档：{documentation_url}",
+        "data": {
+          "base_url": "BookStack URL",
+          "token_id": "API 令牌 ID",
+          "token_secret": "API 令牌密钥",
+          "verify_ssl": "验证 TLS 证书（自签名证书请禁用）"
+        }
+      },
+      "book": {
+        "title": "选择目标书籍",
+        "description": "Home Assistant 应同步到哪本书？页面上手动添加的内容将被保留。",
+        "data": {
+          "book_id": "目标书籍",
+          "sync_interval": "同步间隔"
+        }
+      },
+      "reauth_confirm": {
+        "title": "更新 BookStack 令牌",
+        "description": "BookStack 拒绝了 {base_url} 的 API 令牌。请在 BookStack 中创建新令牌，并将 ID 和密钥粘贴到此处 — URL 和目标书籍保持不变。",
+        "data": {
+          "token_id": "API 令牌 ID",
+          "token_secret": "API 令牌密钥"
+        }
+      },
+      "reconfigure": {
+        "title": "调整 BookStack 连接",
+        "description": "更改此连接的 URL、令牌或 TLS 设置。目标书籍和所有页面映射都将保留。URL 必须指向与之前相同的 BookStack 实例。",
+        "data": {
+          "base_url": "BookStack URL",
+          "token_id": "API 令牌 ID",
+          "token_secret": "API 令牌密钥",
+          "verify_ssl": "验证 TLS 证书（自签名证书请禁用）"
+        }
+      }
+    },
+    "error": {
+      "auth": "API 令牌被拒绝或权限不足。",
+      "connection": "无法连接到 BookStack。",
+      "no_books": "在此 BookStack 实例中未找到书籍。请先创建目标书籍。",
+      "unknown": "意外错误 — 请检查 Home Assistant 日志。",
+      "base_url_invalid_scheme": "URL 必须以 http:// 或 https:// 开头。",
+      "base_url_missing_host": "URL 不完整 — 缺少主机名。"
+    },
+    "abort": {
+      "already_configured": "此 BookStack 实例已配置。",
+      "reauth_successful": "令牌已更新 — BookStack 连接已恢复。",
+      "reconfigure_successful": "连接已更新 — BookStack Sync 已重新配置。",
+      "url_mismatch": "新 URL 指向另一个 BookStack 实例。请删除原始条目并添加新条目。"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "BookStack Sync 设置",
+        "data": {
+          "book_id": "目标书籍",
+          "sync_interval": "同步间隔",
+          "excluded_areas": "排除的区域（不会被同步）",
+          "output_language": "BookStack 页面语言"
+        }
+      }
+    }
+  },
+  "selector": {
+    "sync_interval": {
+      "options": {
+        "hourly": "每小时",
+        "daily": "每天",
+        "manual": "仅手动（服务调用）"
+      }
+    },
+    "output_language": {
+      "options": {
+        "auto": "与 Home Assistant 一致（自动）",
+        "de": "德语",
+        "en": "英语"
+      }
+    }
+  },
+  "services": {
+    "run_now": {
+      "name": "立即同步",
+      "description": "立即开始同步，无需等待间隔。"
+    },
+    "preview": {
+      "name": "同步预览",
+      "description": "记录将创建/更新哪些页面，但不向 BookStack 写入任何内容。"
+    }
+  },
+  "entity": {
+    "sensor": {
+      "sync_status": {
+        "name": "同步状态",
+        "state": {
+          "ok": "OK",
+          "error": "错误",
+          "never_run": "尚未运行",
+          "syncing": "同步进行中"
+        }
+      }
+    },
+    "button": {
+      "run_now": {
+        "name": "立即同步"
+      },
+      "preview": {
+        "name": "同步预览（测试运行）"
+      }
+    }
+  },
+  "issues": {
+    "bookstack_unreachable": {
+      "title": "BookStack 无法访问",
+      "description": "BookStack Sync 集成在连续 {count} 次同步中均无法访问 BookStack 实例。常见原因：BookStack 容器已停止、网络问题或反向代理拒绝连接。下一次成功的同步将自动解决此通知。"
+    },
+    "page_tampered": {
+      "title": "页面的 AUTO 块已被手动编辑",
+      "description": "BookStack 中的页面「{page_title}」具有在 Home Assistant 之外编辑过的 AUTO 块。集成在同步期间跳过了此页面，以免覆盖您的更改。请将您的笔记移至 MANUAL 块，或撤销 AUTO 块中的更改，以便下次同步可以再次更新该页面。"
+    }
+  },
+  "exceptions": {
+    "bookstack_unreachable": {
+      "message": "BookStack 实例无法访问（详细信息请参阅 Home Assistant 日志）。"
+    },
+    "bookstack_auth_failed": {
+      "message": "BookStack 拒绝了 API 令牌。请在 BookStack 中更新令牌并使用 Reauth 流程。"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add 26 translation files mirroring `en.json` structure: 22 EU languages (bg, cs, da, el, es, et, fi, fr, ga, hr, hu, it, lt, lv, mt, nl, pl, pt, ro, sk, sl, sv) plus zh-Hans, nb, uk, th
- Combined with existing `de.json` + `en.json`, BookStack Sync now ships with translations for 28 locales — covering all 24 official EU languages and the most-requested non-EU additions
- Keep technical terms (BookStack, API, Token, TLS, MANUAL, AUTO, Home Assistant, Reauth) in English; preserve all `{placeholder}` markers exactly
- Bump `manifest.json` version to 0.12.0

## Test plan
- [x] All 28 translation files parse as valid JSON
- [x] All 28 files have identical key structure to `en.json` (no missing/extra keys)
- [x] All `{placeholder}` markers (`{base_url}`, `{count}`, `{documentation_url}`, `{page_title}`) preserved across every file
- [x] ruff check clean
- [x] ruff format --check clean
- [ ] CI green (Hassfest + tests)

Generated with Claude Code