### PR TITLE
V0.13.1: UX fixes after first v0.13.0 deployment

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,5 +1,9 @@
 # BookStack Sync für Home Assistant
 
+> Verfügbar in: **Deutsch** · [English](README.md)
+>
+> *(Die HA-UI der Integration selbst ist seit v0.12.0 in 28 Sprachen lokalisiert — diese README gibt es in DE + EN.)*
+
 Eine Home-Assistant-Custom-Integration, die dein gesamtes HA-Setup automatisch in
 ein bestehendes Book deiner [BookStack](https://www.bookstackapp.com/)-Wiki-Instanz
 synchronisiert. Manuell hinzugefügte Inhalte in den Wiki-Pages bleiben dabei

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # BookStack Sync for Home Assistant
 
+> Available in: **English** · [Deutsch](README.de.md)
+>
+> *(The integration's HA UI itself is localised in 28 languages since v0.12.0 — this README exists in DE + EN.)*
+
 A Home Assistant custom integration (installable via HACS) that
 documents your entire HA setup as markdown pages inside an existing
 [BookStack](https://www.bookstackapp.com/) wiki book and keeps it in
@@ -10,8 +14,6 @@ across syncs.** Every page is split into an auto-generated section and
 a manual section by markdown markers. The integration only ever
 rewrites the auto block — your notes, quirks, password references and
 "why we set option X" comments live in the manual block forever.
-
-> **Auch auf Deutsch verfügbar**: [README.de.md](README.de.md)
 
 ## What gets documented
 
@@ -308,22 +310,26 @@ moves them to the right chapter automatically.
 
 ## Known limitations
 
-- **One BookStack book per HA instance.** Multiple books are not
-  supported in v0.5; you'd need multiple HA instances.
 - **No bidirectional sync.** Edits in BookStack outside the manual
   block are detected, logged, and the page is skipped — not merged
   back into HA.
 - **Sync is HA-state-driven.** Renaming an area or device renames the
   page on next sync; the old page becomes orphan and gets a tombstone
   banner. Manual cleanup of tombstoned pages is left to the user.
-- **Languages: DE + EN only.** Other locales fall back to English in
-  the page output. Adding a language is a matter of populating
-  `_strings.py`; PRs welcome.
+- **Page-output languages: DE + EN only.** The integration UI itself
+  is localised in 28 languages (since v0.12.0), but the *content*
+  written into BookStack pages is German or English. Adding a content
+  language is a matter of populating `_strings.py`; PRs welcome.
 - **Excluded areas hide their devices.** A device assigned only to an
   excluded area disappears from the wiki entirely. If you also want
   the device, give it a second area outside the excluded set.
 - **API token has full book-level access.** BookStack does not offer
   per-page tokens; the integration uses whatever the token can reach.
+
+> *Multiple BookStack books / multiple BookStack instances **are**
+> supported* — add the integration once per target. Each config entry
+> is keyed by base URL and gets its own coordinator, storage and
+> status sensor.
 
 ## Non-goals
 

--- a/custom_components/bookstack_sync/config_flow.py
+++ b/custom_components/bookstack_sync/config_flow.py
@@ -52,6 +52,7 @@ from .const import (
 _ERR_INVALID_SCHEME = "base_url_invalid_scheme"
 _ERR_MISSING_HOST = "base_url_missing_host"
 _ERR_PATH_INVALID = "path_invalid"
+_ERR_EXPORT_ALREADY_ENABLED = "export_already_enabled_elsewhere"
 
 
 def _validate_base_url(raw: str) -> str:
@@ -434,11 +435,49 @@ class BookStackSyncOptionsFlow(OptionsFlow):
                     candidate = Path(export_path)
                     if not candidate.is_absolute() or not candidate.parent.exists():
                         errors[CONF_EXPORT_PATH] = _ERR_PATH_INVALID
+                # Single-writer rule: only one config entry may have the
+                # markdown export enabled at a time. Two entries running
+                # the export — even at different paths — would still
+                # write the same idempotency ledger key collisions and
+                # confuse external indexers; refuse upfront with a clear
+                # error pointing at the other entry.
+                for other in self.hass.config_entries.async_entries(DOMAIN):
+                    if other.entry_id == self.config_entry.entry_id:
+                        continue
+                    if other.options.get(
+                        CONF_EXPORT_ENABLED,
+                        DEFAULT_EXPORT_ENABLED,
+                    ):
+                        errors[CONF_EXPORT_ENABLED] = _ERR_EXPORT_ALREADY_ENABLED
+                        break
             if not errors:
+                new_book_id = int(user_input[CONF_BOOK_ID])
+                # When the user picks a different book the integration title
+                # (= visible name on the integration card and the device name)
+                # would otherwise still show the old book — the OptionsFlow's
+                # ``async_create_entry`` doesn't touch the title. Detect the
+                # change here and propagate via ``async_update_entry`` so the
+                # UI follows the user's choice.
+                old_book_id_raw = self.config_entry.options.get(
+                    CONF_BOOK_ID
+                ) or self.config_entry.data.get(CONF_BOOK_ID)
+                if old_book_id_raw is not None and int(old_book_id_raw) != new_book_id:
+                    new_title = next(
+                        (
+                            f"BookStack: {book.get('name', new_book_id)}"
+                            for book in self._books
+                            if int(book["id"]) == new_book_id
+                        ),
+                        self.config_entry.title,
+                    )
+                    self.hass.config_entries.async_update_entry(
+                        self.config_entry,
+                        title=new_title,
+                    )
                 return self.async_create_entry(
                     title="",
                     data={
-                        CONF_BOOK_ID: int(user_input[CONF_BOOK_ID]),
+                        CONF_BOOK_ID: new_book_id,
                         CONF_SYNC_INTERVAL: user_input[CONF_SYNC_INTERVAL],
                         CONF_EXCLUDED_AREAS: user_input.get(CONF_EXCLUDED_AREAS, []),
                         CONF_OUTPUT_LANGUAGE: user_input.get(

--- a/custom_components/bookstack_sync/manifest.json
+++ b/custom_components/bookstack_sync/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dibi73/ha-bookstack-sync/issues",
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.13.0"
+  "version": "0.13.1"
 }

--- a/custom_components/bookstack_sync/strings.json
+++ b/custom_components/bookstack_sync/strings.json
@@ -44,7 +44,9 @@
       "no_books": "In dieser BookStack-Instanz wurde kein Book gefunden. Lege zuerst manuell ein Ziel-Book an.",
       "unknown": "Unbekannter Fehler – siehe Home-Assistant-Log.",
       "base_url_invalid_scheme": "URL muss mit http:// oder https:// beginnen.",
-      "base_url_missing_host": "URL ist unvollständig – Hostname fehlt."
+      "base_url_missing_host": "URL ist unvollständig – Hostname fehlt.",
+      "path_invalid": "Pfad muss absolut sein und das Elternverzeichnis muss bereits existieren.",
+      "export_already_enabled_elsewhere": "Markdown-Export ist bereits in einer anderen BookStack-Sync-Instanz aktiviert. Pro Home-Assistant-Setup darf nur eine Instanz exportieren — sonst kollidieren die Markdown-Dateien. Schalte den Export bei der anderen Instanz erst aus."
     },
     "abort": {
       "already_configured": "Diese BookStack-Instanz ist bereits konfiguriert.",
@@ -61,7 +63,15 @@
           "book_id": "Ziel-Book",
           "sync_interval": "Sync-Intervall",
           "excluded_areas": "Ausgeschlossene Räume (werden nicht synchronisiert)",
-          "output_language": "Sprache der BookStack-Pages"
+          "output_language": "Sprache der BookStack-Pages",
+          "export_enabled": "Markdown-Rückexport aktivieren (standardmäßig aus)",
+          "export_path": "Export-Ordner (absoluter Pfad)",
+          "export_after_sync": "Export nach jedem Sync automatisch ausführen"
+        },
+        "data_description": {
+          "export_enabled": "Standardmäßig aus. Wenn aktiv, werden BookStack-Pages zusätzlich als reine Markdown-Dateien zurückgeschrieben — als Eingabe für RAG/LLM-Pipelines. Verbraucht Speicherplatz und CPU bei jedem Lauf, daher bewusst zu aktivieren.",
+          "export_path": "Wohin die Markdown-Dateien geschrieben werden. Muss absolut sein, das Eltern­verzeichnis muss bereits existieren.",
+          "export_after_sync": "Nur wirksam, wenn „Markdown-Rückexport aktivieren\" eingeschaltet ist."
         }
       }
     }
@@ -90,6 +100,20 @@
     "preview": {
       "name": "Sync-Vorschau",
       "description": "Loggt, welche Pages erstellt/aktualisiert würden, schreibt aber nichts in BookStack."
+    },
+    "export_markdown": {
+      "name": "Markdown-Export (Opt-in)",
+      "description": "Schreibt jede gemanagte BookStack-Page als Markdown-Datei mit YAML-Frontmatter idempotent in den konfigurierten Ordner. Standardmäßig deaktiviert — vorher in den Integrationsoptionen einschalten.",
+      "fields": {
+        "dry_run": {
+          "name": "Trockenlauf",
+          "description": "Loggt was geschrieben würde, ohne tatsächlich Dateien anzulegen."
+        },
+        "output_path": {
+          "name": "Ausgabepfad-Override",
+          "description": "Übersteuert den konfigurierten Pfad nur für diesen einen Aufruf."
+        }
+      }
     }
   },
   "entity": {
@@ -129,6 +153,9 @@
     },
     "bookstack_auth_failed": {
       "message": "BookStack hat das API-Token abgelehnt. Erneuere den Token in BookStack und nutze den Reauth-Flow."
+    },
+    "export_disabled": {
+      "message": "Markdown-Export ist deaktiviert. Schalte ihn in den Integrationsoptionen unter „Markdown-Rückexport aktivieren\" ein, bevor du diesen Service aufrufst."
     }
   }
 }

--- a/custom_components/bookstack_sync/sync.py
+++ b/custom_components/bookstack_sync/sync.py
@@ -505,6 +505,18 @@ def _post_sync_notification(
     report: SyncReport,
     strings: dict[str, str],
 ) -> None:
+    """
+    Surface a persistent notification only when something needs attention.
+
+    Successful runs are silent — the status sensor + integration card already
+    show "ok", and a green-bell-every-night spam is more noise than value.
+    Errors and tampering-related skips do warrant a notification, because
+    those are exactly the cases the user has to act on.
+    """
+    has_errors = bool(report.errors)
+    has_skipped = bool(report.skipped_conflict)
+    if not has_errors and not has_skipped:
+        return
     body = strings["notification_body_template"].format(
         created=len(report.created),
         updated=len(report.updated),

--- a/custom_components/bookstack_sync/translations/bg.json
+++ b/custom_components/bookstack_sync/translations/bg.json
@@ -45,7 +45,8 @@
       "unknown": "Неочаквана грешка — проверете Home Assistant журнала.",
       "base_url_invalid_scheme": "URL трябва да започва с http:// или https://.",
       "base_url_missing_host": "URL е непълен — липсва име на хост.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Тази BookStack инстанция вече е конфигурирана.",

--- a/custom_components/bookstack_sync/translations/cs.json
+++ b/custom_components/bookstack_sync/translations/cs.json
@@ -45,7 +45,8 @@
       "unknown": "Neočekávaná chyba — zkontrolujte protokol Home Assistant.",
       "base_url_invalid_scheme": "URL musí začínat http:// nebo https://.",
       "base_url_missing_host": "URL je neúplná — chybí název hostitele.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Tato instance BookStack je již nakonfigurována.",

--- a/custom_components/bookstack_sync/translations/da.json
+++ b/custom_components/bookstack_sync/translations/da.json
@@ -45,7 +45,8 @@
       "unknown": "Uventet fejl — tjek Home Assistant-loggen.",
       "base_url_invalid_scheme": "URL'en skal starte med http:// eller https://.",
       "base_url_missing_host": "URL'en er ufuldstændig — værtsnavn mangler.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Denne BookStack-instans er allerede konfigureret.",

--- a/custom_components/bookstack_sync/translations/de.json
+++ b/custom_components/bookstack_sync/translations/de.json
@@ -45,7 +45,8 @@
       "unknown": "Unbekannter Fehler – siehe Home-Assistant-Log.",
       "base_url_invalid_scheme": "URL muss mit http:// oder https:// beginnen.",
       "base_url_missing_host": "URL ist unvollständig – Hostname fehlt.",
-      "path_invalid": "Pfad muss absolut sein und das Elternverzeichnis muss bereits existieren."
+      "path_invalid": "Pfad muss absolut sein und das Elternverzeichnis muss bereits existieren.",
+      "export_already_enabled_elsewhere": "Markdown-Export ist bereits in einer anderen BookStack-Sync-Instanz aktiviert. Pro Home-Assistant-Setup darf nur eine Instanz exportieren — sonst kollidieren die Markdown-Dateien. Schalte den Export bei der anderen Instanz erst aus."
     },
     "abort": {
       "already_configured": "Diese BookStack-Instanz ist bereits konfiguriert.",

--- a/custom_components/bookstack_sync/translations/el.json
+++ b/custom_components/bookstack_sync/translations/el.json
@@ -45,7 +45,8 @@
       "unknown": "Απρόσμενο σφάλμα — ελέγξτε το αρχείο καταγραφής Home Assistant.",
       "base_url_invalid_scheme": "Η URL πρέπει να ξεκινά με http:// ή https://.",
       "base_url_missing_host": "Η URL είναι ελλιπής — λείπει το όνομα κεντρικού υπολογιστή.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Αυτή η εγκατάσταση BookStack είναι ήδη ρυθμισμένη.",

--- a/custom_components/bookstack_sync/translations/en.json
+++ b/custom_components/bookstack_sync/translations/en.json
@@ -45,7 +45,8 @@
       "unknown": "Unexpected error - check the Home Assistant log.",
       "base_url_invalid_scheme": "URL must start with http:// or https://.",
       "base_url_missing_host": "URL is incomplete - hostname missing.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "This BookStack instance is already configured.",

--- a/custom_components/bookstack_sync/translations/es.json
+++ b/custom_components/bookstack_sync/translations/es.json
@@ -45,7 +45,8 @@
       "unknown": "Error inesperado — revisa el registro de Home Assistant.",
       "base_url_invalid_scheme": "La URL debe empezar por http:// o https://.",
       "base_url_missing_host": "La URL está incompleta — falta el nombre de host.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Esta instancia de BookStack ya está configurada.",

--- a/custom_components/bookstack_sync/translations/et.json
+++ b/custom_components/bookstack_sync/translations/et.json
@@ -45,7 +45,8 @@
       "unknown": "Ootamatu viga — kontrolli Home Assistanti logi.",
       "base_url_invalid_scheme": "URL peab algama http:// või https:// -ga.",
       "base_url_missing_host": "URL on puudulik — hosti nimi puudub.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "See BookStacki eksemplar on juba seadistatud.",

--- a/custom_components/bookstack_sync/translations/fi.json
+++ b/custom_components/bookstack_sync/translations/fi.json
@@ -45,7 +45,8 @@
       "unknown": "Odottamaton virhe — tarkista Home Assistantin loki.",
       "base_url_invalid_scheme": "URL:n on alettava merkinnällä http:// tai https://.",
       "base_url_missing_host": "URL on epätäydellinen — isäntänimi puuttuu.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Tämä BookStack-instanssi on jo määritetty.",

--- a/custom_components/bookstack_sync/translations/fr.json
+++ b/custom_components/bookstack_sync/translations/fr.json
@@ -45,7 +45,8 @@
       "unknown": "Erreur inattendue — consultez le journal Home Assistant.",
       "base_url_invalid_scheme": "L'URL doit commencer par http:// ou https://.",
       "base_url_missing_host": "L'URL est incomplète — nom d'hôte manquant.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Cette instance BookStack est déjà configurée.",

--- a/custom_components/bookstack_sync/translations/ga.json
+++ b/custom_components/bookstack_sync/translations/ga.json
@@ -45,7 +45,8 @@
       "unknown": "Earráid gan choinne — seiceáil loga Home Assistant.",
       "base_url_invalid_scheme": "Ní mór do URL tosú le http:// nó https://.",
       "base_url_missing_host": "Tá an URL neamhiomlán — ainm óstaigh ar iarraidh.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Tá an sampla BookStack seo cumraithe cheana féin.",

--- a/custom_components/bookstack_sync/translations/hr.json
+++ b/custom_components/bookstack_sync/translations/hr.json
@@ -45,7 +45,8 @@
       "unknown": "Neočekivana pogreška — provjerite Home Assistant zapisnik.",
       "base_url_invalid_scheme": "URL mora započinjati s http:// ili https://.",
       "base_url_missing_host": "URL je nepotpun — naziv hosta nedostaje.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Ova BookStack instanca je već konfigurirana.",

--- a/custom_components/bookstack_sync/translations/hu.json
+++ b/custom_components/bookstack_sync/translations/hu.json
@@ -45,7 +45,8 @@
       "unknown": "Váratlan hiba — ellenőrizze a Home Assistant naplóját.",
       "base_url_invalid_scheme": "Az URL-nek http:// vagy https:// karakterekkel kell kezdődnie.",
       "base_url_missing_host": "Az URL hiányos — a hosztnév hiányzik.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Ez a BookStack példány már konfigurálva van.",

--- a/custom_components/bookstack_sync/translations/it.json
+++ b/custom_components/bookstack_sync/translations/it.json
@@ -45,7 +45,8 @@
       "unknown": "Errore imprevisto — controlla il registro di Home Assistant.",
       "base_url_invalid_scheme": "L'URL deve iniziare con http:// o https://.",
       "base_url_missing_host": "L'URL è incompleto — manca il nome host.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Questa istanza BookStack è già configurata.",

--- a/custom_components/bookstack_sync/translations/lt.json
+++ b/custom_components/bookstack_sync/translations/lt.json
@@ -45,7 +45,8 @@
       "unknown": "Netikėta klaida — patikrinkite Home Assistant žurnalą.",
       "base_url_invalid_scheme": "URL turi prasidėti http:// arba https://.",
       "base_url_missing_host": "URL nepilnas — trūksta pagrindinio kompiuterio pavadinimo.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Šis BookStack egzempliorius jau sukonfigūruotas.",

--- a/custom_components/bookstack_sync/translations/lv.json
+++ b/custom_components/bookstack_sync/translations/lv.json
@@ -45,7 +45,8 @@
       "unknown": "Negaidīta kļūda — pārbaudiet Home Assistant žurnālu.",
       "base_url_invalid_scheme": "URL ir jāsākas ar http:// vai https://.",
       "base_url_missing_host": "URL ir nepilnīgs — trūkst resursdatora nosaukuma.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Šī BookStack instance jau ir konfigurēta.",

--- a/custom_components/bookstack_sync/translations/mt.json
+++ b/custom_components/bookstack_sync/translations/mt.json
@@ -45,7 +45,8 @@
       "unknown": "Żball mhux mistenni — iċċekkja l-log ta' Home Assistant.",
       "base_url_invalid_scheme": "L-URL għandu jibda b'http:// jew https://.",
       "base_url_missing_host": "L-URL huwa inkomplet — l-isem tal-host nieqes.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Din l-istanza BookStack hija diġà kkonfigurata.",

--- a/custom_components/bookstack_sync/translations/nb.json
+++ b/custom_components/bookstack_sync/translations/nb.json
@@ -45,7 +45,8 @@
       "unknown": "Uventet feil — sjekk Home Assistant-loggen.",
       "base_url_invalid_scheme": "URL-en må starte med http:// eller https://.",
       "base_url_missing_host": "URL-en er ufullstendig — vertsnavnet mangler.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Denne BookStack-instansen er allerede konfigurert.",

--- a/custom_components/bookstack_sync/translations/nl.json
+++ b/custom_components/bookstack_sync/translations/nl.json
@@ -45,7 +45,8 @@
       "unknown": "Onverwachte fout — controleer het Home Assistant-logboek.",
       "base_url_invalid_scheme": "URL moet beginnen met http:// of https://.",
       "base_url_missing_host": "URL is onvolledig — hostnaam ontbreekt.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Deze BookStack-instantie is al geconfigureerd.",

--- a/custom_components/bookstack_sync/translations/pl.json
+++ b/custom_components/bookstack_sync/translations/pl.json
@@ -45,7 +45,8 @@
       "unknown": "Nieoczekiwany błąd — sprawdź dziennik Home Assistant.",
       "base_url_invalid_scheme": "Adres URL musi zaczynać się od http:// lub https://.",
       "base_url_missing_host": "Adres URL jest niekompletny — brakuje nazwy hosta.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Ta instancja BookStack jest już skonfigurowana.",

--- a/custom_components/bookstack_sync/translations/pt.json
+++ b/custom_components/bookstack_sync/translations/pt.json
@@ -45,7 +45,8 @@
       "unknown": "Erro inesperado — verifique o registo do Home Assistant.",
       "base_url_invalid_scheme": "O URL deve começar por http:// ou https://.",
       "base_url_missing_host": "O URL está incompleto — falta o nome do anfitrião.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Esta instância BookStack já está configurada.",

--- a/custom_components/bookstack_sync/translations/ro.json
+++ b/custom_components/bookstack_sync/translations/ro.json
@@ -45,7 +45,8 @@
       "unknown": "Eroare neașteptată — verificați jurnalul Home Assistant.",
       "base_url_invalid_scheme": "URL-ul trebuie să înceapă cu http:// sau https://.",
       "base_url_missing_host": "URL-ul este incomplet — lipsește numele gazdei.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Această instanță BookStack este deja configurată.",

--- a/custom_components/bookstack_sync/translations/sk.json
+++ b/custom_components/bookstack_sync/translations/sk.json
@@ -45,7 +45,8 @@
       "unknown": "Neočakávaná chyba — skontrolujte protokol Home Assistant.",
       "base_url_invalid_scheme": "URL musí začínať http:// alebo https://.",
       "base_url_missing_host": "URL je neúplné — chýba názov hostiteľa.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Táto inštancia BookStack je už nakonfigurovaná.",

--- a/custom_components/bookstack_sync/translations/sl.json
+++ b/custom_components/bookstack_sync/translations/sl.json
@@ -45,7 +45,8 @@
       "unknown": "Nepričakovana napaka — preverite dnevnik Home Assistant.",
       "base_url_invalid_scheme": "URL se mora začeti s http:// ali https://.",
       "base_url_missing_host": "URL je nepopoln — manjka ime gostitelja.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Ta primerek BookStack je že konfiguriran.",

--- a/custom_components/bookstack_sync/translations/sv.json
+++ b/custom_components/bookstack_sync/translations/sv.json
@@ -45,7 +45,8 @@
       "unknown": "Oväntat fel — kontrollera Home Assistant-loggen.",
       "base_url_invalid_scheme": "URL:en måste börja med http:// eller https://.",
       "base_url_missing_host": "URL:en är ofullständig — värdnamnet saknas.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Denna BookStack-instans är redan konfigurerad.",

--- a/custom_components/bookstack_sync/translations/th.json
+++ b/custom_components/bookstack_sync/translations/th.json
@@ -45,7 +45,8 @@
       "unknown": "ข้อผิดพลาดที่ไม่คาดคิด — โปรดตรวจสอบบันทึกของ Home Assistant",
       "base_url_invalid_scheme": "URL ต้องขึ้นต้นด้วย http:// หรือ https://",
       "base_url_missing_host": "URL ไม่สมบูรณ์ — ขาดชื่อโฮสต์",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "อินสแตนซ์ BookStack นี้ได้รับการกำหนดค่าแล้ว",

--- a/custom_components/bookstack_sync/translations/uk.json
+++ b/custom_components/bookstack_sync/translations/uk.json
@@ -45,7 +45,8 @@
       "unknown": "Несподівана помилка — перевірте журнал Home Assistant.",
       "base_url_invalid_scheme": "URL має починатися з http:// або https://.",
       "base_url_missing_host": "URL неповний — відсутнє ім'я хоста.",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "Цей екземпляр BookStack уже налаштовано.",

--- a/custom_components/bookstack_sync/translations/zh-Hans.json
+++ b/custom_components/bookstack_sync/translations/zh-Hans.json
@@ -45,7 +45,8 @@
       "unknown": "意外错误 — 请检查 Home Assistant 日志。",
       "base_url_invalid_scheme": "URL 必须以 http:// 或 https:// 开头。",
       "base_url_missing_host": "URL 不完整 — 缺少主机名。",
-      "path_invalid": "Path must be absolute and the parent directory must already exist."
+      "path_invalid": "Path must be absolute and the parent directory must already exist.",
+      "export_already_enabled_elsewhere": "Markdown export is already enabled on another BookStack Sync instance. Only one instance per Home Assistant setup may export - otherwise the Markdown files collide. Disable the export on the other instance first."
     },
     "abort": {
       "already_configured": "此 BookStack 实例已配置。",

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -8,7 +8,7 @@ rendering, tombstoning, page mapping persistence.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.helpers import (
@@ -234,3 +234,97 @@ async def test_english_run_creates_english_titled_chapters(
     # And no German leftovers.
     assert "Räume" not in chapter_titles
     assert "Geräte" not in chapter_titles
+
+
+async def test_clean_sync_emits_no_notification(
+    hass: HomeAssistant,
+    store: BookStackSyncStore,
+    strings: dict[str, str],
+) -> None:
+    """
+    Regression: a healthy sync run is silent.
+
+    Users explicitly asked for no green-bell after every successful sync.
+    The status sensor + integration card already show "ok"; another
+    persistent notification is just noise.
+    """
+    state: dict[str, Any] = {}
+    client = _fake_client_with_state(state)
+    area_reg = ar.async_get(hass)
+    area_reg.async_create("Living Room")
+
+    with patch(
+        "custom_components.bookstack_sync.sync.async_create_notification",
+    ) as notify:
+        report = await run_sync(hass, client, store, 1, strings)
+
+    assert report.errors == []
+    assert report.skipped_conflict == []
+    notify.assert_not_called()
+
+
+async def test_sync_with_errors_emits_notification(
+    hass: HomeAssistant,
+    store: BookStackSyncStore,
+    strings: dict[str, str],
+) -> None:
+    """A sync that hit at least one error still surfaces a notification."""
+    state: dict[str, Any] = {}
+    client = _fake_client_with_state(state)
+    area_reg = ar.async_get(hass)
+    area_reg.async_create("Living Room")
+
+    # Force every page write to fail so the run produces errors.
+    from custom_components.bookstack_sync.api import BookStackApiError  # noqa: PLC0415
+
+    client.create_page = AsyncMock(side_effect=BookStackApiError("boom"))
+
+    with patch(
+        "custom_components.bookstack_sync.sync.async_create_notification",
+    ) as notify:
+        report = await run_sync(hass, client, store, 1, strings)
+
+    assert report.errors  # the run did record at least one error
+    notify.assert_called_once()
+
+
+async def test_sync_with_skipped_conflict_emits_notification(
+    hass: HomeAssistant,
+    store: BookStackSyncStore,
+    strings: dict[str, str],
+) -> None:
+    """Tampering-detected skips also warrant a notification."""
+    state: dict[str, Any] = {}
+    client = _fake_client_with_state(state)
+    area_reg = ar.async_get(hass)
+    area_reg.async_create("Living Room")
+
+    # First run creates the pages cleanly.
+    await run_sync(hass, client, store, 1, strings)
+
+    # Mutate one stored page's auto block in BookStack to simulate the user
+    # editing inside the AUTO marker. The next sync must detect tampering
+    # and skip — and now the run should emit a notification.
+    page_id, page = next(iter(state["pages"].items()))
+    state["pages"][page_id] = {
+        **page,
+        "markdown": page["markdown"].replace(
+            "Auto-generated",
+            "Auto-generated [HACKED]",
+        ),
+    }
+
+    with patch(
+        "custom_components.bookstack_sync.sync.async_create_notification",
+    ) as notify:
+        report = await run_sync(hass, client, store, 1, strings)
+
+    if report.skipped_conflict:
+        notify.assert_called_once()
+    else:
+        # Marker-block layout changed → no skip happened. In that case the
+        # test is degenerate; surface it loudly so a future refactor doesn't
+        # silently mask the regression we care about.
+        pytest.fail(
+            "Expected tamper detection to produce skipped_conflict; got none",
+        )


### PR DESCRIPTION
Bundles five small UX fixes that surfaced after rolling out v0.13.0 in production.

## Summary
- **Notification noise gone.** `sync.py` only posts a persistent notification when the run had errors or skipped-conflict pages; successful runs are silent.
- **`strings.json` parity.** v0.13.0 added the new options/services/exceptions keys to `translations/*.json` but missed `strings.json` — HA's UI fell back to raw keys (`export_enabled`, `export_path`, `output_language`). Mirrored fully now.
- **Title updates on book change.** Changing the target book in *Configure* now updates the integration entry title (and the device card name) via `async_update_entry`. Previously the new book_id was persisted but the card kept showing the old book.
- **Single-writer guard for the Markdown export.** Only one config entry may have `export_enabled=true` at a time — two entries writing to a shared filesystem layout would clobber each other and confuse RAG indexers. New translation key `export_already_enabled_elsewhere` explains.
- **README cleanup.** Dropped the stale "One BookStack book per HA instance, multiple books not supported in v0.5" claim (multi-instance has worked for many releases). Reformatted the language-link line to one inline pair.

## Test plan
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] All 28 translation files: key parity with `en.json`, all `{placeholder}` markers preserved
- [x] `strings.json` now matches `translations/en.json` key-set
- [ ] CI green (Hassfest + HACS + Ruff + pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
