### PR TITLE
V0.13.2: tampering false-positive + drop redundant export_after_sync toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,20 +192,22 @@ states, MQTT topic, …]
 [your manual notes — preserved verbatim from BookStack]
 ```
 
-Trigger options:
+Trigger:
+
+Once `export_enabled` is on, every successful sync also writes the
+Markdown files — no automation needed. The
+`bookstack_sync.export_markdown` service stays available for ad-hoc
+triggers (e.g. „force a fresh export now").
 
 ```yaml
-# Daily at 03:30 (after the sync at 03:00)
+# Optional: trigger an extra export at a specific time.
 automation:
-  - alias: BookStack export
+  - alias: BookStack export at 03:30
     trigger:
       - platform: time
         at: "03:30:00"
     action:
       - service: bookstack_sync.export_markdown
-
-# Or: enable "Run export automatically after each sync" in the
-# integration's options — no automation needed.
 ```
 
 Full schema and stack-specific snippets in

--- a/custom_components/bookstack_sync/config_flow.py
+++ b/custom_components/bookstack_sync/config_flow.py
@@ -27,7 +27,6 @@ from .const import (
     CONF_BASE_URL,
     CONF_BOOK_ID,
     CONF_EXCLUDED_AREAS,
-    CONF_EXPORT_AFTER_SYNC,
     CONF_EXPORT_ENABLED,
     CONF_EXPORT_PATH,
     CONF_OUTPUT_LANGUAGE,
@@ -35,7 +34,6 @@ from .const import (
     CONF_TOKEN_ID,
     CONF_TOKEN_SECRET,
     CONF_VERIFY_SSL,
-    DEFAULT_EXPORT_AFTER_SYNC,
     DEFAULT_EXPORT_ENABLED,
     DEFAULT_EXPORT_SUBDIR,
     DEFAULT_INTERVAL,
@@ -486,12 +484,6 @@ class BookStackSyncOptionsFlow(OptionsFlow):
                         ),
                         CONF_EXPORT_ENABLED: export_enabled,
                         CONF_EXPORT_PATH: export_path,
-                        CONF_EXPORT_AFTER_SYNC: bool(
-                            user_input.get(
-                                CONF_EXPORT_AFTER_SYNC,
-                                DEFAULT_EXPORT_AFTER_SYNC,
-                            ),
-                        ),
                     },
                 )
 
@@ -529,11 +521,6 @@ class BookStackSyncOptionsFlow(OptionsFlow):
             CONF_EXPORT_PATH,
             self.hass.config.path(DEFAULT_EXPORT_SUBDIR),
         )
-        current_export_after_sync = self.config_entry.options.get(
-            CONF_EXPORT_AFTER_SYNC,
-            DEFAULT_EXPORT_AFTER_SYNC,
-        )
-
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
@@ -577,10 +564,6 @@ class BookStackSyncOptionsFlow(OptionsFlow):
                         CONF_EXPORT_PATH,
                         default=current_export_path,
                     ): selector.TextSelector(),
-                    vol.Required(
-                        CONF_EXPORT_AFTER_SYNC,
-                        default=current_export_after_sync,
-                    ): selector.BooleanSelector(),
                 },
             ),
             errors=errors,

--- a/custom_components/bookstack_sync/const.py
+++ b/custom_components/bookstack_sync/const.py
@@ -76,13 +76,13 @@ SERVICE_EXPORT_MARKDOWN = "export_markdown"
 
 # Markdown back-export to a folder of plain files (issue #61).
 # Off by default — wasted disk + CPU otherwise. The user opts in via the
-# options flow, then the run_now-style service or the optional auto-trigger
-# after each sync produces ``<output>/<chapter>/<slug>.md`` per managed page.
+# options flow; once on, every successful sync also exports. The manual
+# ``bookstack_sync.export_markdown`` service stays available for ad-hoc
+# triggers. (v0.13.2 dropped the ``export_after_sync`` toggle that gated
+# the auto-trigger separately — it was redundant with ``export_enabled``.)
 CONF_EXPORT_ENABLED = "export_enabled"
 CONF_EXPORT_PATH = "export_path"
-CONF_EXPORT_AFTER_SYNC = "export_after_sync"
 DEFAULT_EXPORT_ENABLED = False
-DEFAULT_EXPORT_AFTER_SYNC = False
 DEFAULT_EXPORT_SUBDIR = "bookstack_export"
 EXPORT_STORAGE_KEY_FMT = "bookstack_sync.{entry_id}.export"
 EXPORT_FORMAT_VERSION = "1"

--- a/custom_components/bookstack_sync/coordinator.py
+++ b/custom_components/bookstack_sync/coordinator.py
@@ -15,12 +15,10 @@ from .api import BookStackApiAuthError, BookStackApiError
 from .const import (
     CONF_BOOK_ID,
     CONF_EXCLUDED_AREAS,
-    CONF_EXPORT_AFTER_SYNC,
     CONF_EXPORT_ENABLED,
     CONF_EXPORT_PATH,
     CONF_OUTPUT_LANGUAGE,
     CONF_SYNC_INTERVAL,
-    DEFAULT_EXPORT_AFTER_SYNC,
     DEFAULT_EXPORT_ENABLED,
     DEFAULT_INTERVAL,
     DEFAULT_OUTPUT_LANGUAGE,
@@ -206,16 +204,15 @@ class BookStackSyncCoordinator(DataUpdateCoordinator[SyncReport]):
         """
         Run the markdown back-export if the user has explicitly opted in.
 
-        Both flags must be true: ``export_enabled`` is the master kill
-        switch (default off), ``export_after_sync`` chooses *when* to
-        run (post-sync vs only on explicit service call). Errors are
-        logged but never raised — the sync itself already succeeded
-        and we don't want a missing folder to flip the sensor red.
+        ``export_enabled`` is the only switch (default off): once on, every
+        successful sync also exports. v0.13.2 dropped the separate
+        ``export_after_sync`` toggle — it was redundant, since enabling the
+        export feature already implies wanting it to run. Errors are logged
+        but never raised — the sync itself already succeeded and we don't
+        want a missing folder to flip the sensor red.
         """
         options = self.config_entry.options or {}
         if not options.get(CONF_EXPORT_ENABLED, DEFAULT_EXPORT_ENABLED):
-            return
-        if not options.get(CONF_EXPORT_AFTER_SYNC, DEFAULT_EXPORT_AFTER_SYNC):
             return
         try:
             result = await export_run(

--- a/custom_components/bookstack_sync/manifest.json
+++ b/custom_components/bookstack_sync/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dibi73/ha-bookstack-sync/issues",
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.13.1"
+  "version": "0.13.2"
 }

--- a/custom_components/bookstack_sync/strings.json
+++ b/custom_components/bookstack_sync/strings.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Ausgeschlossene Räume (werden nicht synchronisiert)",
           "output_language": "Sprache der BookStack-Pages",
           "export_enabled": "Markdown-Rückexport aktivieren (standardmäßig aus)",
-          "export_path": "Export-Ordner (absoluter Pfad)",
-          "export_after_sync": "Export nach jedem Sync automatisch ausführen"
+          "export_path": "Export-Ordner (absoluter Pfad)"
         },
         "data_description": {
           "export_enabled": "Standardmäßig aus. Wenn aktiv, werden BookStack-Pages zusätzlich als reine Markdown-Dateien zurückgeschrieben — als Eingabe für RAG/LLM-Pipelines. Verbraucht Speicherplatz und CPU bei jedem Lauf, daher bewusst zu aktivieren.",
-          "export_path": "Wohin die Markdown-Dateien geschrieben werden. Muss absolut sein, das Eltern­verzeichnis muss bereits existieren.",
-          "export_after_sync": "Nur wirksam, wenn „Markdown-Rückexport aktivieren\" eingeschaltet ist."
+          "export_path": "Wohin die Markdown-Dateien geschrieben werden. Muss absolut sein, das Eltern­verzeichnis muss bereits existieren."
         }
       }
     }

--- a/custom_components/bookstack_sync/sync.py
+++ b/custom_components/bookstack_sync/sync.py
@@ -607,7 +607,32 @@ async def _sync_one(  # noqa: PLR0913 - cohesive sync step, splitting hurts clar
     )
 
     if merged.manual_block_tampered:
-        if mapping.hash_origin != "bookstack":
+        if not merged.auto_block_changed:
+            # Hash drift, not tampering (issue follow-up to #58):
+            # BookStack's current AUTO content matches what HA would
+            # render right now, but the hash we stored after our last
+            # write has drifted from it. That means BookStack
+            # normalised the markdown sometime between the immediate
+            # create/update response (which we hashed) and the
+            # subsequent read — so the user did NOT edit the page,
+            # the storage just lost track. Re-hash silently against
+            # what BookStack actually has now and continue.
+            LOGGER.info(
+                "BookStack page %s (id=%s): stored hash drifted from "
+                "BookStack content, but content still matches HA's "
+                "current render — re-hashing silently (no tampering).",
+                page.title,
+                mapping.page_id,
+            )
+            mapping = PageMapping(
+                page_id=mapping.page_id,
+                auto_block_hash=existing_auto_hash or "",
+                last_seen=mapping.last_seen,
+                tombstoned_at=mapping.tombstoned_at,
+                hash_origin="bookstack",
+            )
+            store.set(page.key, mapping)
+        elif mapping.hash_origin != "bookstack":
             # Migration path (#58): legacy ``write``-origin hashes can't
             # reliably detect tampering against BookStack's normalised
             # storage. Trust the user, fall through to a fresh write

--- a/custom_components/bookstack_sync/translations/bg.json
+++ b/custom_components/bookstack_sync/translations/bg.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Изключени зони (няма да бъдат синхронизирани)",
           "output_language": "Език на BookStack страниците",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/cs.json
+++ b/custom_components/bookstack_sync/translations/cs.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Vyloučené oblasti (nebudou synchronizovány)",
           "output_language": "Jazyk stránek BookStack",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/da.json
+++ b/custom_components/bookstack_sync/translations/da.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Ekskluderede områder (synkroniseres ikke)",
           "output_language": "Sprog for BookStack-sider",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/de.json
+++ b/custom_components/bookstack_sync/translations/de.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Ausgeschlossene Räume (werden nicht synchronisiert)",
           "output_language": "Sprache der BookStack-Pages",
           "export_enabled": "Markdown-Rückexport aktivieren (standardmäßig aus)",
-          "export_path": "Export-Ordner (absoluter Pfad)",
-          "export_after_sync": "Export nach jedem Sync automatisch ausführen"
+          "export_path": "Export-Ordner (absoluter Pfad)"
         },
         "data_description": {
           "export_enabled": "Standardmäßig aus. Wenn aktiv, werden BookStack-Pages zusätzlich als reine Markdown-Dateien zurückgeschrieben — als Eingabe für RAG/LLM-Pipelines. Verbraucht Speicherplatz und CPU bei jedem Lauf, daher bewusst zu aktivieren.",
-          "export_path": "Wohin die Markdown-Dateien geschrieben werden. Muss absolut sein, das Eltern­verzeichnis muss bereits existieren.",
-          "export_after_sync": "Nur wirksam, wenn „Markdown-Rückexport aktivieren\" eingeschaltet ist."
+          "export_path": "Wohin die Markdown-Dateien geschrieben werden. Muss absolut sein, das Eltern­verzeichnis muss bereits existieren."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/el.json
+++ b/custom_components/bookstack_sync/translations/el.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Εξαιρούμενες περιοχές (δεν θα συγχρονιστούν)",
           "output_language": "Γλώσσα των σελίδων BookStack",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/en.json
+++ b/custom_components/bookstack_sync/translations/en.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Excluded areas (will not be synced)",
           "output_language": "Language of the BookStack pages",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/es.json
+++ b/custom_components/bookstack_sync/translations/es.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Áreas excluidas (no se sincronizarán)",
           "output_language": "Idioma de las páginas de BookStack",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/et.json
+++ b/custom_components/bookstack_sync/translations/et.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Välistatud alad (ei sünkroonita)",
           "output_language": "BookStacki lehtede keel",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/fi.json
+++ b/custom_components/bookstack_sync/translations/fi.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Pois jätetyt alueet (ei synkronoida)",
           "output_language": "BookStack-sivujen kieli",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/fr.json
+++ b/custom_components/bookstack_sync/translations/fr.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Zones exclues (ne seront pas synchronisées)",
           "output_language": "Langue des pages BookStack",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/ga.json
+++ b/custom_components/bookstack_sync/translations/ga.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Limistéir eisiata (ní dhéanfar sioncronú orthu)",
           "output_language": "Teanga na leathanach BookStack",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/hr.json
+++ b/custom_components/bookstack_sync/translations/hr.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Isključena područja (neće se sinkronizirati)",
           "output_language": "Jezik BookStack stranica",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/hu.json
+++ b/custom_components/bookstack_sync/translations/hu.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Kizárt területek (nem lesznek szinkronizálva)",
           "output_language": "BookStack oldalak nyelve",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/it.json
+++ b/custom_components/bookstack_sync/translations/it.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Aree escluse (non saranno sincronizzate)",
           "output_language": "Lingua delle pagine BookStack",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/lt.json
+++ b/custom_components/bookstack_sync/translations/lt.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Neįtrauktos sritys (nebus sinchronizuojamos)",
           "output_language": "BookStack puslapių kalba",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/lv.json
+++ b/custom_components/bookstack_sync/translations/lv.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Izslēgtie apgabali (netiks sinhronizēti)",
           "output_language": "BookStack lapu valoda",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/mt.json
+++ b/custom_components/bookstack_sync/translations/mt.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Żoni esklużi (mhux ser jiġu sinkronizzati)",
           "output_language": "Lingwa tal-paġni BookStack",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/nb.json
+++ b/custom_components/bookstack_sync/translations/nb.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Ekskluderte områder (vil ikke synkroniseres)",
           "output_language": "Språk for BookStack-sider",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/nl.json
+++ b/custom_components/bookstack_sync/translations/nl.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Uitgesloten gebieden (worden niet gesynchroniseerd)",
           "output_language": "Taal van BookStack-pagina's",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/pl.json
+++ b/custom_components/bookstack_sync/translations/pl.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Wykluczone obszary (nie będą synchronizowane)",
           "output_language": "Język stron BookStack",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/pt.json
+++ b/custom_components/bookstack_sync/translations/pt.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Áreas excluídas (não serão sincronizadas)",
           "output_language": "Idioma das páginas BookStack",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/ro.json
+++ b/custom_components/bookstack_sync/translations/ro.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Zone excluse (nu vor fi sincronizate)",
           "output_language": "Limba paginilor BookStack",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/sk.json
+++ b/custom_components/bookstack_sync/translations/sk.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Vylúčené oblasti (nebudú synchronizované)",
           "output_language": "Jazyk stránok BookStack",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/sl.json
+++ b/custom_components/bookstack_sync/translations/sl.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Izključena območja (ne bodo sinhronizirana)",
           "output_language": "Jezik strani BookStack",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/sv.json
+++ b/custom_components/bookstack_sync/translations/sv.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Uteslutna områden (kommer inte synkroniseras)",
           "output_language": "Språk för BookStack-sidor",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/th.json
+++ b/custom_components/bookstack_sync/translations/th.json
@@ -65,13 +65,11 @@
           "excluded_areas": "พื้นที่ที่ยกเว้น (จะไม่ถูกซิงค์)",
           "output_language": "ภาษาของหน้า BookStack",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/uk.json
+++ b/custom_components/bookstack_sync/translations/uk.json
@@ -65,13 +65,11 @@
           "excluded_areas": "Виключені області (не синхронізуватимуться)",
           "output_language": "Мова сторінок BookStack",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/custom_components/bookstack_sync/translations/zh-Hans.json
+++ b/custom_components/bookstack_sync/translations/zh-Hans.json
@@ -65,13 +65,11 @@
           "excluded_areas": "排除的区域（不会被同步）",
           "output_language": "BookStack 页面语言",
           "export_enabled": "Enable Markdown back-export (off by default)",
-          "export_path": "Export folder (absolute path)",
-          "export_after_sync": "Run export automatically after each sync"
+          "export_path": "Export folder (absolute path)"
         },
         "data_description": {
           "export_enabled": "Off by default. When on, BookStack pages are written back as plain Markdown files for use as RAG / LLM input. Costs disk space and CPU on every export run, which is why it must be enabled consciously.",
-          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist.",
-          "export_after_sync": "Only effective when 'Enable Markdown back-export' is on."
+          "export_path": "Where to write the Markdown files. Must be absolute and the parent directory must exist."
         }
       }
     }

--- a/docs/EXPORT.md
+++ b/docs/EXPORT.md
@@ -20,9 +20,13 @@ The export is **disabled by default**. Reasons:
 To turn it on, open the integration's *Configure* dialog
 (**Settings → Devices & Services → BookStack Sync → Configure**) and
 enable **Markdown-Export aktivieren** (*Enable Markdown back-export*).
-You can then either call the service `bookstack_sync.export_markdown`
-manually / from automations, or enable **Export nach jedem Sync
-automatisch ausführen** to chain the export after every successful sync.
+Once on, every successful sync also writes the Markdown files; the
+`bookstack_sync.export_markdown` service stays available for ad-hoc
+triggers (e.g. an extra timed run).
+
+> v0.13.2 dropped the separate *„Export nach jedem Sync"* toggle —
+> it was redundant with the master switch (enabling the export
+> already implies wanting it to happen).
 
 ## Output layout
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -328,3 +328,52 @@ async def test_sync_with_skipped_conflict_emits_notification(
         pytest.fail(
             "Expected tamper detection to produce skipped_conflict; got none",
         )
+
+
+async def test_drifted_stored_hash_does_not_trigger_tampering(
+    hass: HomeAssistant,
+    store: BookStackSyncStore,
+    strings: dict[str, str],
+) -> None:
+    """
+    Regression for the v0.13.1 false-positive on Acurite-Rain-25:
+
+    BookStack normalises markdown sometime between the immediate
+    create/update response (which we hashed) and the subsequent read
+    on the next sync. The hash drifts, the previous tampering check
+    fired even though the user did NOT edit the page in BookStack.
+    Fix: when the AUTO content still matches HA's current render,
+    treat it as drift, re-hash silently, no notification, no skip.
+    """
+    state: dict[str, Any] = {}
+    client = _fake_client_with_state(state)
+    area_reg = ar.async_get(hass)
+    area_reg.async_create("Living Room")
+
+    # First sync: creates everything, stores hashes from BookStack
+    # response.
+    await run_sync(hass, client, store, 1, strings)
+
+    # Simulate hash drift: corrupt every stored mapping's
+    # ``auto_block_hash`` while leaving ``hash_origin = "bookstack"``.
+    # The BookStack content is untouched (so ``existing_auto_hash``
+    # still equals the new render).
+    from custom_components.bookstack_sync.store import PageMapping  # noqa: PLC0415
+
+    for key, mapping in store.all().items():
+        store.set(
+            key,
+            PageMapping(
+                page_id=mapping.page_id,
+                auto_block_hash="cafebabe" * 8,  # not the real hash
+                last_seen=mapping.last_seen,
+                tombstoned_at=mapping.tombstoned_at,
+                hash_origin="bookstack",
+            ),
+        )
+
+    # Second sync should NOT raise tampering — content matches.
+    report2 = await run_sync(hass, client, store, 1, strings)
+    assert report2.skipped_conflict == []
+    assert report2.tampered_page_keys == []
+    assert report2.errors == []


### PR DESCRIPTION
Two user-reported issues bundled into a v0.13.2 patch.

## Summary

### 1. Tampering false-positive (`Acurite-Rain-25` and likely others)
v0.11.0's round-trip-hash assumed BookStack returns the canonical, normalised markdown in the immediate create/update response. In practice BookStack appears to normalise **between** the create-response and a subsequent read on the next sync — the stored hash drifts from BookStack's stored content even though nobody edited the page.

**Fix:** in `sync.py`, when `manual_block_tampered=True` but `auto_block_changed=False` (BookStack's current AUTO content still matches what HA would render right now), it's hash drift, not tampering. Re-hash silently, no warning, no skip. Real tampering still triggers the warning + skip path.

Regression test added in `tests/test_sync.py::test_drifted_stored_hash_does_not_trigger_tampering`.

### 2. `export_after_sync` toggle removed
User-feedback: the second boolean was redundant with `export_enabled`. Anyone who turns the master switch on wants the export to happen — that's the whole point. The ad-hoc `bookstack_sync.export_markdown` service stays available for "force a fresh export now" automations.

Affected files: `const.py`, `coordinator.py`, `config_flow.py`, all 28 `translations/*.json` + `strings.json`, `README.md`, `docs/EXPORT.md`. No migration needed — stale option keys in existing entries are silently ignored on read.

## Test plan
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] All 28 translation files: key parity with `en.json`
- [x] `strings.json` parity with `translations/en.json`
- [x] New regression test for hash drift
- [ ] CI green (Hassfest + HACS + Ruff + pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
