### PR TITLE
V0.13.3 hotfix: 260 false-positive tampering reports per sync (CRLF + NFC drift)

### DIFF
--- a/custom_components/bookstack_sync/manifest.json
+++ b/custom_components/bookstack_sync/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dibi73/ha-bookstack-sync/issues",
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.13.2"
+  "version": "0.13.3"
 }

--- a/custom_components/bookstack_sync/merge.py
+++ b/custom_components/bookstack_sync/merge.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+import unicodedata
 from dataclasses import dataclass
 
 from .const import (
@@ -55,19 +56,35 @@ class MergeResult:
     manual_block_tampered: bool
 
 
-def hash_auto_block(auto_body: str) -> str:
+def _normalise_for_hash(auto_body: str) -> str:
     r"""
-    Compute the whitespace-normalised hash of the AUTO body (without markers).
+    Aggressively normalise the AUTO body before hashing.
 
-    Stripping is critical because ``build_page_body`` writes the auto body
-    via ``auto_body.strip()`` and ``extract_auto_block`` reads it via
-    ``.strip('\n')`` - if we hashed the raw render output (which our
-    renderers end with a trailing newline) the write-time hash would never
-    match the read-time hash, every page after its initial creation would
-    be flagged as ``manual_block_tampered`` and the next sync would skip
-    it entirely.
+    Sequence (each step is invariant against a known BookStack-side
+    normalisation pass that historically broke our tampering detection):
+
+    1. Newline normalisation: ``\r\n`` and bare ``\r`` → ``\n``.
+       BookStack stores LF internally on Linux, but on some setups the
+       reverse-proxy layer or the markdown editor injects CRLF, and our
+       prior strip-only hash treated LF and CRLF as different content,
+       producing 260+ false-positive tampering reports per sync.
+
+    2. Unicode NFC: ``é`` (U+00E9) and ``é`` (U+0065 + U+0301) collapse
+       to one form. BookStack's editor normalises to NFC; HA renderers
+       sometimes produce NFD via the underlying string sources.
+
+    3. Trailing/leading whitespace: ``strip()``. ``build_page_body``
+       writes through ``auto_body.strip()`` and ``extract_auto_block``
+       reads via ``.strip('\n')``, so the hash must match either side.
     """
-    return hashlib.sha256(auto_body.strip().encode("utf-8")).hexdigest()
+    text = auto_body.replace("\r\n", "\n").replace("\r", "\n")
+    text = unicodedata.normalize("NFC", text)
+    return text.strip()
+
+
+def hash_auto_block(auto_body: str) -> str:
+    """Compute the whitespace+unicode-normalised hash of the AUTO body."""
+    return hashlib.sha256(_normalise_for_hash(auto_body).encode("utf-8")).hexdigest()
 
 
 def _legacy_unstripped_hash(auto_body: str) -> str:

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -42,6 +42,32 @@ class TestHashAutoBlock:
         assert hash_auto_block("") == hash_auto_block("\n")
         assert hash_auto_block("") == hash_auto_block("   ")
 
+    def test_crlf_vs_lf_invariant(self) -> None:
+        """v0.13.3: BookStack stores CRLF, HA writes LF — hashes must match.
+
+        Regression for the 260+ false-positive tampering reports the user
+        hit on every sync after v0.13.0. ``\\r\\n`` and bare ``\\r`` are
+        normalised to ``\\n`` before hashing, otherwise every page would
+        be re-flagged as tampered on each sync.
+        """
+        assert hash_auto_block("LineA\nLineB") == hash_auto_block("LineA\r\nLineB")
+        assert hash_auto_block("LineA\nLineB") == hash_auto_block("LineA\rLineB")
+        assert hash_auto_block("a\nb\nc") == hash_auto_block("a\r\nb\r\nc")
+
+    def test_unicode_nfc_vs_nfd_invariant(self) -> None:
+        """v0.13.3: NFC and NFD-encoded umlauts hash identically.
+
+        BookStack's editor normalises to NFC. HA's render output sometimes
+        carries NFD-encoded characters from underlying registry strings;
+        without NFC normalisation in the hash, those pages would
+        false-positive on every sync.
+        """
+        # "é" as a single NFC code point vs "e" + combining acute accent.
+        nfc = "Café"
+        nfd = "Café"
+        assert nfc != nfd  # raw bytes differ
+        assert hash_auto_block(nfc) == hash_auto_block(nfd)
+
 
 class TestRoundTrip:
     """build_page_body + extract_auto_block must round-trip the AUTO body."""


### PR DESCRIPTION
**Hotfix.** User hit ~260 "AUTO block was edited manually" repair-issues per sync run on v0.13.2.

## Cause
v0.13.2's drift detector only handled **boundary** whitespace (`.strip()`) — but BookStack normalises content **inside** the AUTO block too:
- CRLF line endings vs HA's bare LF on Linux
- Unicode NFC vs NFD (BookStack editor → NFC; HA registry strings sometimes NFD)

Both make the per-byte hash differ even though the page reads identically. The v0.13.2 fix `not auto_block_changed` couldn't trigger because both sides re-hashed differently — the false-positive flooded back.

## Fix
New `merge._normalise_for_hash`:
1. `\r\n` and `\r` → `\n`
2. NFC unicode normalisation
3. `.strip()`

`hash_auto_block` runs every input through it. Write and read hashes now match regardless of BookStack's normalisation pass.

## Migration
Existing stored `bookstack`-origin hashes from <0.13.3 don't match the new normalised hash on read — but the v0.13.2 drift detector then finds the current BookStack content matching HA's render under the new hash, silently re-hashes, and the mapping settles within **one** sync cycle. No code-side migration needed; the user's existing 260 tampered-page repair issues will auto-resolve on the next successful sync.

## Test plan
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] New test `test_crlf_vs_lf_invariant`: every CRLF/CR variant hashes equal to LF
- [x] New test `test_unicode_nfc_vs_nfd_invariant`: NFC `é` (U+00E9) and NFD `e + ◌́` (U+0065 U+0301) hash equal
- [ ] CI green (Hassfest + HACS + Ruff + pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
