### PR TITLE
V0.13.4 hotfix: stale tamper repair-issues survived restart forever

### DIFF
--- a/custom_components/bookstack_sync/coordinator.py
+++ b/custom_components/bookstack_sync/coordinator.py
@@ -106,16 +106,25 @@ class BookStackSyncCoordinator(DataUpdateCoordinator[SyncReport]):
         """
         Create / auto-resolve ``page_tampered`` repair issues.
 
-        Diffs the current sync's tampered keys against the previous run.
-        New tampered pages → fresh repair issue. Pages no longer
-        tampered → repair issue auto-deleted.
+        Source of truth is the HA issue-registry, NOT the in-memory cache:
+        ``self._active_tamper_keys`` resets on every HA restart, which used
+        to leave stale repair issues from previous sessions hanging around
+        forever (v0.13.3 follow-up). We now query the registry directly so
+        the diff against the current sync's tampered keys produces the
+        correct delete-set even right after a restart.
         """
         current = dict(
             zip(report.tampered_page_keys, report.tampered_page_titles, strict=True),
         )
-        new_keys = set(current.keys()) - self._active_tamper_keys
-        resolved_keys = self._active_tamper_keys - set(current.keys())
         entry_id = self.config_entry.entry_id
+        prefix = f"{REPAIR_ISSUE_TAMPERED}_{entry_id}_"
+        existing = {
+            issue_id.removeprefix(prefix)
+            for (issue_domain, issue_id) in ir.async_get(self.hass).issues
+            if issue_domain == DOMAIN and issue_id.startswith(prefix)
+        }
+        new_keys = set(current.keys()) - existing
+        resolved_keys = existing - set(current.keys())
 
         for key in new_keys:
             ir.async_create_issue(
@@ -134,6 +143,8 @@ class BookStackSyncCoordinator(DataUpdateCoordinator[SyncReport]):
                 f"{REPAIR_ISSUE_TAMPERED}_{entry_id}_{key}",
             )
 
+        # In-memory cache kept for tests + diagnostics; no longer the
+        # authoritative source.
         self._active_tamper_keys = set(current.keys())
 
     def _note_failure(self) -> None:

--- a/custom_components/bookstack_sync/manifest.json
+++ b/custom_components/bookstack_sync/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dibi73/ha-bookstack-sync/issues",
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.13.3"
+  "version": "0.13.4"
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -192,3 +192,58 @@ async def test_dry_run_does_not_record_last_run(
 
     assert coord.last_run is None
     assert coord.last_report is None
+
+
+async def test_stale_tamper_issues_resolved_after_restart(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """
+    v0.13.4 regression: stale tamper repair-issues from previous sessions
+    are auto-deleted on the first clean sync after restart.
+
+    Before v0.13.4 the reconciler only consulted ``self._active_tamper_keys``
+    which is in-memory and resets on every coordinator construction. Old
+    repair-issues raised in a previous HA session would therefore never be
+    cleaned up — the user saw 260+ stale notifications hanging around even
+    after the v0.13.3 hash fix had stopped producing new ones.
+    """
+    from homeassistant.helpers import issue_registry as ir  # noqa: PLC0415
+
+    from custom_components.bookstack_sync.const import (  # noqa: PLC0415
+        DOMAIN,
+        REPAIR_ISSUE_TAMPERED,
+    )
+
+    config_entry.add_to_hass(hass)
+
+    # Simulate a previous HA session that raised tamper issues for two
+    # pages and then the user restarted before they could be resolved.
+    entry_id = config_entry.entry_id
+    for key in ("device:abc", "device:def"):
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            f"{REPAIR_ISSUE_TAMPERED}_{entry_id}_{key}",
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=REPAIR_ISSUE_TAMPERED,
+            translation_placeholders={"page_title": f"page-{key}"},
+        )
+
+    # Now construct a fresh coordinator (= post-restart).
+    coord = _make_coordinator(hass, config_entry)
+    assert coord._active_tamper_keys == set()  # in-memory cache empty
+
+    # Simulate a clean sync run — no tampered pages reported.
+    coord._reconcile_tamper_issues(SyncReport())
+
+    # All previously-stored tamper issues for this entry are gone.
+    issue_reg = ir.async_get(hass)
+    remaining = [
+        issue_id
+        for (issue_domain, issue_id) in issue_reg.issues
+        if issue_domain == DOMAIN
+        and issue_id.startswith(f"{REPAIR_ISSUE_TAMPERED}_{entry_id}_")
+    ]
+    assert remaining == [], f"stale tamper issues survived: {remaining}"


### PR DESCRIPTION
**Hotfix-on-Hotfix.** v0.13.3 stopped *producing* tampering false positives, but **existing** repair-issues from before the upgrade stayed put forever — the user reported 260 stale `Vorgestern von BookStack Sync` notifications hanging around even after the hash fix landed.

## Cause
`_reconcile_tamper_issues` diffed the current sync's tampered set only against `self._active_tamper_keys`, an in-memory set initialised empty in `__init__`. Every HA restart wiped the set, so old repair-issues raised in a previous session could never be auto-deleted.

## Fix
Query the **issue registry directly** as the source of truth on every reconcile:

```python
prefix = f"{REPAIR_ISSUE_TAMPERED}_{entry_id}_"
existing = {
    issue_id.removeprefix(prefix)
    for (issue_domain, issue_id) in ir.async_get(self.hass).issues
    if issue_domain == DOMAIN and issue_id.startswith(prefix)
}
resolved_keys = existing - set(current.keys())
```

Stale issues from previous sessions get deleted on the **first clean sync** after restart. In-memory cache kept for tests + diagnostics, no longer authoritative.

## Test plan
- [x] New regression test `test_stale_tamper_issues_resolved_after_restart`: pre-seed registry with stale tamper issues, fresh coordinator, empty SyncReport → nothing remains
- [x] Full suite: 165 passed locally in WSL Ubuntu Python 3.14 in 19s
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [ ] CI green (Hassfest + HACS + Ruff + pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
