### PR TITLE
V0.14.2: multi-instance sync — export-enabled entry runs first

### DIFF
--- a/custom_components/bookstack_sync/manifest.json
+++ b/custom_components/bookstack_sync/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dibi73/ha-bookstack-sync/issues",
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.14.1"
+  "version": "0.14.2"
 }

--- a/custom_components/bookstack_sync/services.py
+++ b/custom_components/bookstack_sync/services.py
@@ -23,12 +23,35 @@ if TYPE_CHECKING:
 
 
 def _coordinators(hass: HomeAssistant) -> list:
-    """Return all loaded BookStack coordinators across config entries."""
-    return [
-        entry.runtime_data.coordinator
+    """
+    Return all loaded BookStack coordinators across config entries.
+
+    v0.14.2: order matters when multiple BookStack instances are
+    configured and one of them has the markdown back-export enabled.
+    The export-enabled instance MUST sync first, otherwise its
+    post-sync export pass would run while the OTHER instances are
+    still in mid-sync — leaving the exported folder with a stale
+    snapshot of one instance and a fresh snapshot of another.
+
+    Sort key: ``not export_enabled`` (False sorts before True), so
+    the single export-enabled entry comes out at index 0; remaining
+    entries keep their config-entry creation order via Python's
+    stable sort.
+    """
+    entries = [
+        entry
         for entry in hass.config_entries.async_entries(DOMAIN)
         if getattr(entry, "runtime_data", None) is not None
     ]
+    entries.sort(
+        key=lambda entry: (
+            not entry.options.get(
+                CONF_EXPORT_ENABLED,
+                DEFAULT_EXPORT_ENABLED,
+            )
+        ),
+    )
+    return [entry.runtime_data.coordinator for entry in entries]
 
 
 async def _require_admin(hass: HomeAssistant, call: ServiceCall) -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,91 @@
+"""Tests for the service-handler helpers in services.py."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bookstack_sync.const import (
+    CONF_BASE_URL,
+    CONF_BOOK_ID,
+    CONF_EXPORT_ENABLED,
+    CONF_TOKEN_ID,
+    CONF_TOKEN_SECRET,
+    DOMAIN,
+)
+from custom_components.bookstack_sync.services import _coordinators
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+def _make_runtime_data(label: str) -> MagicMock:
+    """Stub runtime_data with a labelled coordinator marker."""
+    coordinator = MagicMock()
+    coordinator.label = label
+    rd = MagicMock()
+    rd.coordinator = coordinator
+    return rd
+
+
+async def test_coordinators_export_enabled_first(hass: HomeAssistant) -> None:
+    """
+    v0.14.2: when multiple BookStack instances are configured, the one
+    with markdown export enabled MUST come out first.
+
+    Otherwise its post-sync export would run while the other instances
+    are still mid-sync, leaving the export folder with a stale snapshot.
+    The order between non-export-enabled entries stays stable (config-
+    entry creation order) thanks to Python's stable sort.
+    """
+    # Three entries: A (export OFF), B (export ON), C (export OFF).
+    # Expected order out of _coordinators: B, A, C.
+    for label, export_enabled in (("A", False), ("B", True), ("C", False)):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title=f"BookStack: {label}",
+            unique_id=f"http://bookstack-{label}.local",
+            data={
+                CONF_BASE_URL: f"http://bookstack-{label}.local",
+                CONF_TOKEN_ID: "tid",
+                CONF_TOKEN_SECRET: "tsec",
+                CONF_BOOK_ID: 1,
+            },
+            options={CONF_EXPORT_ENABLED: export_enabled},
+        )
+        entry.add_to_hass(hass)
+        entry.runtime_data = _make_runtime_data(label)
+
+    coords = _coordinators(hass)
+    labels = [c.label for c in coords]
+
+    assert labels[0] == "B", f"export-enabled instance must come first, got {labels!r}"
+    assert labels[1:] == ["A", "C"], (
+        f"non-export entries must keep creation order, got {labels!r}"
+    )
+
+
+async def test_coordinators_no_export_enabled_keeps_natural_order(
+    hass: HomeAssistant,
+) -> None:
+    """If no entry has the export enabled, the order is config-entry creation order."""
+    for label in ("First", "Second", "Third"):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title=f"BookStack: {label}",
+            unique_id=f"http://bookstack-{label}.local",
+            data={
+                CONF_BASE_URL: f"http://bookstack-{label}.local",
+                CONF_TOKEN_ID: "tid",
+                CONF_TOKEN_SECRET: "tsec",
+                CONF_BOOK_ID: 1,
+            },
+            options={},
+        )
+        entry.add_to_hass(hass)
+        entry.runtime_data = _make_runtime_data(label)
+
+    coords = _coordinators(hass)
+    assert [c.label for c in coords] == ["First", "Second", "Third"]


### PR DESCRIPTION
User scenario: two BookStack instances, one of them has markdown back-export enabled. `bookstack_sync.run_now` walked entries in config-entry creation order, so the export-enabled instance might land in the middle. Its post-sync export pass then ran while the OTHER instances were still mid-sync, leaving the exported folder with a stale snapshot of one instance + a fresh snapshot of another. The downstream RAG indexer sees an inconsistent crawl.

## Fix

`services._coordinators` sorts entries by `not export_enabled` before returning. Python's stable sort keeps non-export entries in creation order, the single export-enabled entry floats to index 0. `_handle_run_now` and `_handle_preview` both iterate this list; `_handle_export` filters by `export_enabled` anyway and is unaffected.

The single-writer constraint from v0.13.1 already enforces "at most one entry has `export_enabled = true`", so the sort order is deterministic — at most one entry promotes to head, all others stay natural.

## Test plan
- [x] 176 pass locally in WSL Ubuntu Python 3.14 in 19 s
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- New tests in `tests/test_services.py`:
  - `test_coordinators_export_enabled_first` — A(off), B(on), C(off) → B, A, C
  - `test_coordinators_no_export_enabled_keeps_natural_order`
- [ ] CI green (Hassfest + HACS + Ruff + pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
