### PR TITLE
V0.14.3: force parameter on run_now / preview to overwrite tampered pages

### DIFF
--- a/custom_components/bookstack_sync/coordinator.py
+++ b/custom_components/bookstack_sync/coordinator.py
@@ -178,8 +178,22 @@ class BookStackSyncCoordinator(DataUpdateCoordinator[SyncReport]):
             f"{REPAIR_ISSUE_UNREACHABLE}_{self.config_entry.entry_id}",
         )
 
-    async def async_run_sync(self, *, dry_run: bool = False) -> SyncReport:
-        """Execute a sync immediately, regardless of the schedule."""
+    async def async_run_sync(
+        self,
+        *,
+        dry_run: bool = False,
+        force: bool = False,
+    ) -> SyncReport:
+        """
+        Execute a sync immediately, regardless of the schedule.
+
+        ``force=True`` (v0.14.3) bypasses the tamper-skip path: pages
+        whose stored hash drifted from the BookStack-stored AUTO block
+        AND whose new render genuinely differs (the typical fallout
+        from a version-bump that reshapes the AUTO block) get
+        overwritten instead of skipped. The MANUAL block is preserved
+        either way.
+        """
         async with self._sync_lock:
             self.is_syncing = True
             self.async_update_listeners()
@@ -201,6 +215,7 @@ class BookStackSyncCoordinator(DataUpdateCoordinator[SyncReport]):
                     strings,
                     dry_run=dry_run,
                     excluded_area_ids=excluded_areas,
+                    force=force,
                 )
                 if not dry_run:
                     self.last_run = datetime.now(tz=UTC)

--- a/custom_components/bookstack_sync/manifest.json
+++ b/custom_components/bookstack_sync/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dibi73/ha-bookstack-sync/issues",
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.14.2"
+  "version": "0.14.3"
 }

--- a/custom_components/bookstack_sync/services.py
+++ b/custom_components/bookstack_sync/services.py
@@ -97,15 +97,20 @@ async def async_register_services(hass: HomeAssistant) -> None:
 
     async def _handle_run_now(call: ServiceCall) -> None:
         await _require_admin(hass, call)
+        force = bool(call.data.get("force", False))
         for coordinator in _coordinators(hass):
-            LOGGER.info("Running BookStack sync (run_now)")
-            await coordinator.async_run_sync(dry_run=False)
+            LOGGER.info("Running BookStack sync (run_now, force=%s)", force)
+            await coordinator.async_run_sync(dry_run=False, force=force)
 
     async def _handle_preview(call: ServiceCall) -> None:
         await _require_admin(hass, call)
+        force = bool(call.data.get("force", False))
         for coordinator in _coordinators(hass):
-            LOGGER.info("Running BookStack sync preview (dry-run)")
-            report = await coordinator.async_run_sync(dry_run=True)
+            LOGGER.info(
+                "Running BookStack sync preview (dry-run, force=%s)",
+                force,
+            )
+            report = await coordinator.async_run_sync(dry_run=True, force=force)
             LOGGER.info("Preview result: %s", report.as_dict())
 
     async def _handle_export(call: ServiceCall) -> None:

--- a/custom_components/bookstack_sync/services.yaml
+++ b/custom_components/bookstack_sync/services.yaml
@@ -3,12 +3,33 @@ run_now:
   description: >-
     Runs the BookStack sync immediately for every configured BookStack Sync
     entry, regardless of the configured interval.
+  fields:
+    force:
+      name: Force overwrite tampered pages
+      description: >-
+        When true, pages whose AUTO block looks tampered (stored hash differs
+        from BookStack content) are overwritten instead of skipped. Use this
+        once after a major upgrade that reshapes the AUTO block format. The
+        MANUAL block is always preserved.
+      default: false
+      selector:
+        boolean:
 
 preview:
   name: Sync preview
   description: >-
     Performs a dry-run: logs which pages would be created or updated, but
     writes nothing to BookStack. Useful right after setup or template changes.
+  fields:
+    force:
+      name: Force overwrite tampered pages
+      description: >-
+        Mirror of run_now's force flag — see there. Combined with the dry-run
+        nature of preview this lets you check what would be overwritten before
+        committing.
+      default: false
+      selector:
+        boolean:
 
 export_markdown:
   name: Export Markdown (opt-in)

--- a/custom_components/bookstack_sync/strings.json
+++ b/custom_components/bookstack_sync/strings.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Sofort synchronisieren",
-      "description": "Startet einen Sync sofort, ohne auf das Intervall zu warten."
+      "description": "Startet einen Sync sofort, ohne auf das Intervall zu warten.",
+      "fields": {
+        "force": {
+          "name": "Tampered-Pages erzwungen überschreiben",
+          "description": "Wenn aktiv, werden Pages mit scheinbar manipuliertem AUTO-Block überschrieben statt übersprungen. Einmalig nach großen Upgrades nutzen, die das AUTO-Block-Format ändern. Der MANUAL-Block bleibt unangetastet."
+        }
+      }
     },
     "preview": {
       "name": "Sync-Vorschau",
-      "description": "Loggt, welche Pages erstellt/aktualisiert würden, schreibt aber nichts in BookStack."
+      "description": "Loggt, welche Pages erstellt/aktualisiert würden, schreibt aber nichts in BookStack.",
+      "fields": {
+        "force": {
+          "name": "Tampered-Pages erzwungen überschreiben",
+          "description": "Spiegel zum force-Flag von run_now. In der Vorschau siehst du, welche Pages überschrieben würden, ohne dass tatsächlich geschrieben wird."
+        }
+      }
     },
     "export_markdown": {
       "name": "Markdown-Export (Opt-in)",

--- a/custom_components/bookstack_sync/sync.py
+++ b/custom_components/bookstack_sync/sync.py
@@ -413,6 +413,7 @@ async def run_sync(  # noqa: PLR0912, PLR0913, PLR0915 - cohesive 3-pass entry p
     strings: dict[str, str],
     *,
     dry_run: bool = False,
+    force: bool = False,
     excluded_area_ids: Iterable[str] = (),
 ) -> SyncReport:
     """Execute one full sync cycle and return a report."""
@@ -449,6 +450,7 @@ async def run_sync(  # noqa: PLR0912, PLR0913, PLR0915 - cohesive 3-pass entry p
                 index=step,
                 total=total_steps,
                 dry_run=dry_run,
+                force=force,
             )
             if page_id is not None:
                 page_ids[page.key] = page_id
@@ -481,6 +483,7 @@ async def run_sync(  # noqa: PLR0912, PLR0913, PLR0915 - cohesive 3-pass entry p
                 index=step,
                 total=total_steps,
                 dry_run=dry_run,
+                force=force,
             )
             if page_id is not None:
                 page_ids[page.key] = page_id
@@ -518,6 +521,7 @@ async def run_sync(  # noqa: PLR0912, PLR0913, PLR0915 - cohesive 3-pass entry p
             index=total_steps,
             total=total_steps,
             dry_run=dry_run,
+            force=force,
         )
     except BookStackApiAuthError:
         raise
@@ -600,6 +604,7 @@ async def _sync_one(  # noqa: PLR0913 - cohesive sync step, splitting hurts clar
     index: int,
     total: int,
     dry_run: bool,
+    force: bool = False,
 ) -> int | None:
     """Sync one page; return the BookStack page id (or None on dry-run create)."""
     chapter_id = chapters.get(page.chapter_key) if page.chapter_key else None
@@ -699,11 +704,29 @@ async def _sync_one(  # noqa: PLR0913 - cohesive sync step, splitting hurts clar
                 page.title,
                 mapping.page_id,
             )
+        elif force:
+            # User explicitly opted in to overwrite via the
+            # ``force=true`` service parameter. Used after a major
+            # version bump that reshapes the AUTO block format and
+            # leaves dozens of pages stuck on a residual hash drift
+            # the v0.13.3 normaliser can't catch (real situation
+            # after the v0.14.0 area-page refactor).
+            #
+            # MANUAL block stays preserved (merge_page already kept
+            # it), only the AUTO block is overwritten with the fresh
+            # render.
+            LOGGER.warning(
+                "BookStack page %s (id=%s): force=True — overriding "
+                "tamper check, AUTO block will be overwritten. MANUAL "
+                "block stays preserved.",
+                page.title,
+                mapping.page_id,
+            )
         else:
             LOGGER.warning(
                 "BookStack page %s (id=%s): AUTO block was edited outside "
                 "of Home Assistant - skipping to avoid clobbering manual "
-                "changes.",
+                "changes. Re-run with force=true to override.",
                 page.title,
                 mapping.page_id,
             )

--- a/custom_components/bookstack_sync/translations/bg.json
+++ b/custom_components/bookstack_sync/translations/bg.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Синхронизирай сега",
-      "description": "Стартира синхронизация веднага, без да чака интервала."
+      "description": "Стартира синхронизация веднага, без да чака интервала.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Преглед на синхронизация",
-      "description": "Записва в журнала кои страници ще бъдат създадени/актуализирани, без да пише нищо в BookStack."
+      "description": "Записва в журнала кои страници ще бъдат създадени/актуализирани, без да пише нищо в BookStack.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/cs.json
+++ b/custom_components/bookstack_sync/translations/cs.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Synchronizovat nyní",
-      "description": "Spustí synchronizaci okamžitě, bez čekání na interval."
+      "description": "Spustí synchronizaci okamžitě, bez čekání na interval.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Náhled synchronizace",
-      "description": "Zaznamená do protokolu, které stránky by byly vytvořeny/aktualizovány, ale do BookStack nic nezapisuje."
+      "description": "Zaznamená do protokolu, které stránky by byly vytvořeny/aktualizovány, ale do BookStack nic nezapisuje.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/da.json
+++ b/custom_components/bookstack_sync/translations/da.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Synkronisér nu",
-      "description": "Starter en synkronisering med det samme uden at vente på intervallet."
+      "description": "Starter en synkronisering med det samme uden at vente på intervallet.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Synkroniseringsforhåndsvisning",
-      "description": "Logger hvilke sider der ville blive oprettet/opdateret uden at skrive noget til BookStack."
+      "description": "Logger hvilke sider der ville blive oprettet/opdateret uden at skrive noget til BookStack.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/de.json
+++ b/custom_components/bookstack_sync/translations/de.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Sofort synchronisieren",
-      "description": "Startet einen Sync sofort, ohne auf das Intervall zu warten."
+      "description": "Startet einen Sync sofort, ohne auf das Intervall zu warten.",
+      "fields": {
+        "force": {
+          "name": "Tampered-Pages erzwungen überschreiben",
+          "description": "Wenn aktiv, werden Pages mit scheinbar manipuliertem AUTO-Block überschrieben statt übersprungen. Einmalig nach großen Upgrades nutzen, die das AUTO-Block-Format ändern. Der MANUAL-Block bleibt unangetastet."
+        }
+      }
     },
     "preview": {
       "name": "Sync-Vorschau",
-      "description": "Loggt, welche Pages erstellt/aktualisiert würden, schreibt aber nichts in BookStack."
+      "description": "Loggt, welche Pages erstellt/aktualisiert würden, schreibt aber nichts in BookStack.",
+      "fields": {
+        "force": {
+          "name": "Tampered-Pages erzwungen überschreiben",
+          "description": "Spiegel zum force-Flag von run_now. In der Vorschau siehst du, welche Pages überschrieben würden, ohne dass tatsächlich geschrieben wird."
+        }
+      }
     },
     "export_markdown": {
       "name": "Markdown-Export (Opt-in)",

--- a/custom_components/bookstack_sync/translations/el.json
+++ b/custom_components/bookstack_sync/translations/el.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Συγχρονισμός τώρα",
-      "description": "Ξεκινά συγχρονισμό αμέσως, χωρίς αναμονή για το διάστημα."
+      "description": "Ξεκινά συγχρονισμό αμέσως, χωρίς αναμονή για το διάστημα.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Προεπισκόπηση συγχρονισμού",
-      "description": "Καταγράφει ποιες σελίδες θα δημιουργούνταν/ενημερώνονταν χωρίς να γράφει τίποτα στο BookStack."
+      "description": "Καταγράφει ποιες σελίδες θα δημιουργούνταν/ενημερώνονταν χωρίς να γράφει τίποτα στο BookStack.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/en.json
+++ b/custom_components/bookstack_sync/translations/en.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Sync now",
-      "description": "Trigger a sync immediately without waiting for the interval."
+      "description": "Trigger a sync immediately without waiting for the interval.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Sync preview",
-      "description": "Logs which pages would be created/updated without writing anything to BookStack."
+      "description": "Logs which pages would be created/updated without writing anything to BookStack.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/es.json
+++ b/custom_components/bookstack_sync/translations/es.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Sincronizar ahora",
-      "description": "Inicia una sincronización de inmediato, sin esperar al intervalo."
+      "description": "Inicia una sincronización de inmediato, sin esperar al intervalo.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Vista previa de sincronización",
-      "description": "Registra qué páginas se crearían/actualizarían sin escribir nada en BookStack."
+      "description": "Registra qué páginas se crearían/actualizarían sin escribir nada en BookStack.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/et.json
+++ b/custom_components/bookstack_sync/translations/et.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Sünkrooni kohe",
-      "description": "Käivitab sünkroonimise kohe, ilma intervalli ootamata."
+      "description": "Käivitab sünkroonimise kohe, ilma intervalli ootamata.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Sünkroonimise eelvaade",
-      "description": "Logib, milliseid lehti loodaks/uuendataks, ilma BookStacki midagi kirjutamata."
+      "description": "Logib, milliseid lehti loodaks/uuendataks, ilma BookStacki midagi kirjutamata.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/fi.json
+++ b/custom_components/bookstack_sync/translations/fi.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Synkronoi nyt",
-      "description": "Käynnistää synkronoinnin heti odottamatta väliä."
+      "description": "Käynnistää synkronoinnin heti odottamatta väliä.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Synkronoinnin esikatselu",
-      "description": "Kirjaa, mitkä sivut luotaisiin/päivitettäisiin, mutta ei kirjoita mitään BookStackiin."
+      "description": "Kirjaa, mitkä sivut luotaisiin/päivitettäisiin, mutta ei kirjoita mitään BookStackiin.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/fr.json
+++ b/custom_components/bookstack_sync/translations/fr.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Synchroniser maintenant",
-      "description": "Démarre une synchronisation immédiatement, sans attendre l'intervalle."
+      "description": "Démarre une synchronisation immédiatement, sans attendre l'intervalle.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Aperçu de synchronisation",
-      "description": "Enregistre quelles pages seraient créées/mises à jour sans rien écrire dans BookStack."
+      "description": "Enregistre quelles pages seraient créées/mises à jour sans rien écrire dans BookStack.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/ga.json
+++ b/custom_components/bookstack_sync/translations/ga.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Sioncronú anois",
-      "description": "Tosaíonn sioncronú láithreach gan fanacht leis an eatramh."
+      "description": "Tosaíonn sioncronú láithreach gan fanacht leis an eatramh.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Réamhamharc sioncronaithe",
-      "description": "Logáil cad iad na leathanaigh a chruthófaí/nuashonrófaí gan rud ar bith a scríobh chuig BookStack."
+      "description": "Logáil cad iad na leathanaigh a chruthófaí/nuashonrófaí gan rud ar bith a scríobh chuig BookStack.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/hr.json
+++ b/custom_components/bookstack_sync/translations/hr.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Sinkroniziraj sada",
-      "description": "Pokreće sinkronizaciju odmah, bez čekanja na interval."
+      "description": "Pokreće sinkronizaciju odmah, bez čekanja na interval.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Pregled sinkronizacije",
-      "description": "Bilježi koje bi se stranice kreirale/ažurirale, ali ne piše ništa u BookStack."
+      "description": "Bilježi koje bi se stranice kreirale/ažurirale, ali ne piše ništa u BookStack.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/hu.json
+++ b/custom_components/bookstack_sync/translations/hu.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Szinkronizálás most",
-      "description": "Azonnal elindít egy szinkronizálást az időköz bevárása nélkül."
+      "description": "Azonnal elindít egy szinkronizálást az időköz bevárása nélkül.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Szinkronizálási előnézet",
-      "description": "Naplózza, mely oldalak jönnének létre/frissülnének, anélkül hogy bármit a BookStackbe írna."
+      "description": "Naplózza, mely oldalak jönnének létre/frissülnének, anélkül hogy bármit a BookStackbe írna.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/it.json
+++ b/custom_components/bookstack_sync/translations/it.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Sincronizza ora",
-      "description": "Avvia immediatamente una sincronizzazione senza attendere l'intervallo."
+      "description": "Avvia immediatamente una sincronizzazione senza attendere l'intervallo.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Anteprima sincronizzazione",
-      "description": "Registra quali pagine verrebbero create/aggiornate senza scrivere nulla in BookStack."
+      "description": "Registra quali pagine verrebbero create/aggiornate senza scrivere nulla in BookStack.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/lt.json
+++ b/custom_components/bookstack_sync/translations/lt.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Sinchronizuoti dabar",
-      "description": "Iš karto pradeda sinchronizavimą nelaukiant intervalo."
+      "description": "Iš karto pradeda sinchronizavimą nelaukiant intervalo.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Sinchronizavimo peržiūra",
-      "description": "Užrašo, kurie puslapiai būtų sukurti/atnaujinti, nieko nerašydama į BookStack."
+      "description": "Užrašo, kurie puslapiai būtų sukurti/atnaujinti, nieko nerašydama į BookStack.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/lv.json
+++ b/custom_components/bookstack_sync/translations/lv.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Sinhronizēt tagad",
-      "description": "Nekavējoties sāk sinhronizāciju, negaidot intervālu."
+      "description": "Nekavējoties sāk sinhronizāciju, negaidot intervālu.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Sinhronizācijas priekšskatījums",
-      "description": "Reģistrē, kuras lapas tiktu izveidotas/atjauninātas, nerakstot neko BookStack."
+      "description": "Reģistrē, kuras lapas tiktu izveidotas/atjauninātas, nerakstot neko BookStack.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/mt.json
+++ b/custom_components/bookstack_sync/translations/mt.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Sinkronizza issa",
-      "description": "Tibda sinkronizzazzjoni minnufih mingħajr ma tistenna l-intervall."
+      "description": "Tibda sinkronizzazzjoni minnufih mingħajr ma tistenna l-intervall.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Anteprima ta' sinkronizzazzjoni",
-      "description": "Tirreġistra liema paġni jinħolqu/jiġu aġġornati mingħajr ma tikteb xejn f'BookStack."
+      "description": "Tirreġistra liema paġni jinħolqu/jiġu aġġornati mingħajr ma tikteb xejn f'BookStack.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/nb.json
+++ b/custom_components/bookstack_sync/translations/nb.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Synkroniser nå",
-      "description": "Starter en synkronisering umiddelbart uten å vente på intervallet."
+      "description": "Starter en synkronisering umiddelbart uten å vente på intervallet.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Forhåndsvisning av synkronisering",
-      "description": "Logger hvilke sider som ville bli opprettet/oppdatert uten å skrive noe til BookStack."
+      "description": "Logger hvilke sider som ville bli opprettet/oppdatert uten å skrive noe til BookStack.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/nl.json
+++ b/custom_components/bookstack_sync/translations/nl.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Nu synchroniseren",
-      "description": "Start direct een synchronisatie zonder te wachten op het interval."
+      "description": "Start direct een synchronisatie zonder te wachten op het interval.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Synchronisatievoorbeeld",
-      "description": "Logt welke pagina's zouden worden aangemaakt/bijgewerkt zonder iets naar BookStack te schrijven."
+      "description": "Logt welke pagina's zouden worden aangemaakt/bijgewerkt zonder iets naar BookStack te schrijven.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/pl.json
+++ b/custom_components/bookstack_sync/translations/pl.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Synchronizuj teraz",
-      "description": "Uruchamia synchronizację natychmiast, bez czekania na interwał."
+      "description": "Uruchamia synchronizację natychmiast, bez czekania na interwał.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Podgląd synchronizacji",
-      "description": "Rejestruje, które strony zostałyby utworzone/zaktualizowane, bez zapisywania czegokolwiek do BookStack."
+      "description": "Rejestruje, które strony zostałyby utworzone/zaktualizowane, bez zapisywania czegokolwiek do BookStack.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/pt.json
+++ b/custom_components/bookstack_sync/translations/pt.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Sincronizar agora",
-      "description": "Inicia uma sincronização imediatamente sem aguardar o intervalo."
+      "description": "Inicia uma sincronização imediatamente sem aguardar o intervalo.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Pré-visualização da sincronização",
-      "description": "Regista que páginas seriam criadas/atualizadas sem escrever nada no BookStack."
+      "description": "Regista que páginas seriam criadas/atualizadas sem escrever nada no BookStack.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/ro.json
+++ b/custom_components/bookstack_sync/translations/ro.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Sincronizează acum",
-      "description": "Pornește o sincronizare imediat, fără a aștepta intervalul."
+      "description": "Pornește o sincronizare imediat, fără a aștepta intervalul.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Previzualizare sincronizare",
-      "description": "Înregistrează ce pagini ar fi create/actualizate fără a scrie nimic în BookStack."
+      "description": "Înregistrează ce pagini ar fi create/actualizate fără a scrie nimic în BookStack.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/sk.json
+++ b/custom_components/bookstack_sync/translations/sk.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Synchronizovať teraz",
-      "description": "Spustí synchronizáciu okamžite bez čakania na interval."
+      "description": "Spustí synchronizáciu okamžite bez čakania na interval.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Náhľad synchronizácie",
-      "description": "Zaznamená, ktoré stránky by sa vytvorili/aktualizovali, bez zapisovania čohokoľvek do BookStack."
+      "description": "Zaznamená, ktoré stránky by sa vytvorili/aktualizovali, bez zapisovania čohokoľvek do BookStack.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/sl.json
+++ b/custom_components/bookstack_sync/translations/sl.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Sinhroniziraj zdaj",
-      "description": "Takoj zažene sinhronizacijo brez čakanja na interval."
+      "description": "Takoj zažene sinhronizacijo brez čakanja na interval.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Predogled sinhronizacije",
-      "description": "Beleži, katere strani bi bile ustvarjene/posodobljene, ne da bi karkoli zapisal v BookStack."
+      "description": "Beleži, katere strani bi bile ustvarjene/posodobljene, ne da bi karkoli zapisal v BookStack.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/sv.json
+++ b/custom_components/bookstack_sync/translations/sv.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Synkronisera nu",
-      "description": "Startar en synkronisering omedelbart utan att vänta på intervallet."
+      "description": "Startar en synkronisering omedelbart utan att vänta på intervallet.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Förhandsgranskning av synkronisering",
-      "description": "Loggar vilka sidor som skulle skapas/uppdateras utan att skriva något till BookStack."
+      "description": "Loggar vilka sidor som skulle skapas/uppdateras utan att skriva något till BookStack.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/th.json
+++ b/custom_components/bookstack_sync/translations/th.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "ซิงค์ทันที",
-      "description": "เริ่มการซิงค์ทันทีโดยไม่ต้องรอช่วงเวลา"
+      "description": "เริ่มการซิงค์ทันทีโดยไม่ต้องรอช่วงเวลา",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "ตัวอย่างการซิงค์",
-      "description": "บันทึกว่าหน้าใดจะถูกสร้าง/อัปเดต โดยไม่เขียนอะไรลงใน BookStack"
+      "description": "บันทึกว่าหน้าใดจะถูกสร้าง/อัปเดต โดยไม่เขียนอะไรลงใน BookStack",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/uk.json
+++ b/custom_components/bookstack_sync/translations/uk.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "Синхронізувати зараз",
-      "description": "Запускає синхронізацію негайно, не чекаючи інтервалу."
+      "description": "Запускає синхронізацію негайно, не чекаючи інтервалу.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "Попередній перегляд синхронізації",
-      "description": "Записує, які сторінки було б створено/оновлено, нічого не записуючи в BookStack."
+      "description": "Записує, які сторінки було б створено/оновлено, нічого не записуючи в BookStack.",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/custom_components/bookstack_sync/translations/zh-Hans.json
+++ b/custom_components/bookstack_sync/translations/zh-Hans.json
@@ -93,11 +93,23 @@
   "services": {
     "run_now": {
       "name": "立即同步",
-      "description": "立即开始同步，无需等待间隔。"
+      "description": "立即开始同步，无需等待间隔。",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "When true, pages whose AUTO block looks tampered are overwritten instead of skipped. Use after a major upgrade. MANUAL block stays preserved."
+        }
+      }
     },
     "preview": {
       "name": "同步预览",
-      "description": "记录将创建/更新哪些页面，但不向 BookStack 写入任何内容。"
+      "description": "记录将创建/更新哪些页面，但不向 BookStack 写入任何内容。",
+      "fields": {
+        "force": {
+          "name": "Force overwrite tampered pages",
+          "description": "Mirror of run_now's force flag. With preview, it shows what would be overwritten without actually committing."
+        }
+      }
     },
     "export_markdown": {
       "name": "Export Markdown (opt-in)",

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -377,3 +377,97 @@ async def test_drifted_stored_hash_does_not_trigger_tampering(
     assert report2.skipped_conflict == []
     assert report2.tampered_page_keys == []
     assert report2.errors == []
+
+
+async def test_force_overwrites_tampered_pages(
+    hass: HomeAssistant,
+    store: BookStackSyncStore,
+    strings: dict[str, str],
+) -> None:
+    """
+    v0.14.3: ``force=True`` bypasses the tamper-skip path.
+
+    Real-world trigger: after a major upgrade that reshapes the AUTO
+    block format (e.g. v0.14.0's area-page refactor), residual hash
+    drift the v0.13.3 normaliser can't catch combines with the
+    legitimate content change to make pages look tampered. ``force``
+    is the user-facing escape hatch: overwrite anyway, MANUAL block
+    stays preserved by the merge logic.
+    """
+    state: dict[str, Any] = {}
+    client = _fake_client_with_state(state)
+    area_reg = ar.async_get(hass)
+    area_reg.async_create("Living Room")
+
+    # First run creates pages cleanly.
+    await run_sync(hass, client, store, 1, strings)
+
+    # Simulate hash drift + content change combo: corrupt the stored
+    # hash AND mutate the BookStack-side AUTO content so the next
+    # sync sees the page as legitimately-changed AND tampered.
+    from custom_components.bookstack_sync.store import PageMapping  # noqa: PLC0415
+
+    for key, mapping in store.all().items():
+        store.set(
+            key,
+            PageMapping(
+                page_id=mapping.page_id,
+                auto_block_hash="cafebabe" * 8,
+                last_seen=mapping.last_seen,
+                tombstoned_at=mapping.tombstoned_at,
+                hash_origin="bookstack",
+            ),
+        )
+    page_id, page = next(iter(state["pages"].items()))
+    state["pages"][page_id] = {
+        **page,
+        "markdown": page["markdown"].replace(
+            "Auto-generated",
+            "Auto-generated [drifted]",
+        ),
+    }
+
+    # Without force: the page is skipped.
+    report_skip = await run_sync(hass, client, store, 1, strings)
+    assert report_skip.skipped_conflict, "expected tamper-skip without force"
+
+    # With force=True: overwritten, no skip.
+    report_force = await run_sync(hass, client, store, 1, strings, force=True)
+    assert report_force.skipped_conflict == [], (
+        f"force=True should bypass skip, got {report_force.skipped_conflict!r}"
+    )
+    assert report_force.tampered_page_keys == []
+
+
+async def test_force_default_false_preserves_safety(
+    hass: HomeAssistant,
+    store: BookStackSyncStore,
+    strings: dict[str, str],
+) -> None:
+    """
+    v0.14.3 invariant: when ``force`` is NOT explicitly passed, the
+    tamper-skip protection MUST still fire. The escape hatch is
+    user-opt-in only — no silent regressions on the schedule path.
+    """
+    state: dict[str, Any] = {}
+    client = _fake_client_with_state(state)
+    area_reg = ar.async_get(hass)
+    area_reg.async_create("Living Room")
+
+    await run_sync(hass, client, store, 1, strings)
+
+    # Tamper a single page.
+    page_id, page = next(iter(state["pages"].items()))
+    state["pages"][page_id] = {
+        **page,
+        "markdown": page["markdown"].replace(
+            "Auto-generated",
+            "Auto-generated [tampered]",
+        ),
+    }
+
+    # Default (no force kwarg): the page must be skipped.
+    report = await run_sync(hass, client, store, 1, strings)
+    assert report.skipped_conflict, (
+        "default run_sync (no force) must keep the tamper-skip protection"
+    )


### PR DESCRIPTION
Concrete user report after v0.14.0 rollout: 149 of 400 pages came back as *„AUTO-Block manuell editiert — übersprungen"* — the v0.13.2/v0.13.3 drift detectors couldn't disentangle:

1. residual hash drift the v0.13.3 normaliser doesn't catch (likely smart-quotes, typographic punctuation, or content-specific edge cases)
2. simultaneously, ``auto_block_changed=True`` because v0.14.0 really did reshape the AUTO block format (full device tables → minimal navigation)

→ "real edit + new format" is indistinguishable from "BookStack normalisation drift + new format" → safety wins → 37% of pages stuck.

## Fix: opt-in escape hatch

```yaml
service: bookstack_sync.run_now
data:
  force: true
```

When `force=True` and tamper is detected:
- if the existing AUTO content matches the new render → still treated as silent drift (v0.13.2 path, no warning, no skip)
- otherwise: log a WARNING (`force=True — overriding tamper check`), fall through to write, MANUAL block stays preserved by the existing merge logic

Default `force=False` keeps the protection unchanged for the schedule path and any caller that doesn't opt in.

Plumbing: `force` flows from service handlers → coordinator `async_run_sync` → `run_sync` → `_sync_one`. All three call sites in the 3-pass `run_sync` updated.

`services.yaml` gets a `force` field on both `run_now` and `preview`. Translations: full DE + EN, EN-stub merge across the other 26 locales (+ `strings.json`).

## Test plan
- [x] 178 pass locally in WSL Ubuntu Python 3.14 in 24 s
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- New tests in `test_sync.py`:
  - `test_force_overwrites_tampered_pages` — corrupted hash + mutated AUTO body; without `force` the page is skipped, with `force` it's overwritten
  - `test_force_default_false_preserves_safety` — invariant that the default path keeps the protection (no silent regression)
- All 28 translation files key-parity with `en.json`
- [ ] CI green (Hassfest + HACS + Ruff + pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
