### PR TITLE
V0.14.4: Markdown links replace BookStack transclusion in overview/area pages

### DIFF
--- a/custom_components/bookstack_sync/manifest.json
+++ b/custom_components/bookstack_sync/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dibi73/ha-bookstack-sync/issues",
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.14.3"
+  "version": "0.14.4"
 }

--- a/custom_components/bookstack_sync/renderer.py
+++ b/custom_components/bookstack_sync/renderer.py
@@ -120,36 +120,45 @@ def render_overview_auto_block(
     snapshot: HASnapshot,
     now: datetime,
     strings: dict[str, str],
-    page_links: dict[str, int] | None = None,
+    page_links: dict[str, str] | None = None,
 ) -> str:
     """
     Render the AUTO block of the overview page.
 
-    v0.14.1: stripped to pure navigation. Per user feedback, an *Übersicht*
-    is exactly that — a hub of cross-page links to the actual content,
-    nothing more. The pre-v0.14.1 layout duplicated derived information
-    (8-line statistics block, per-area device counts) that the user could
-    just as well read off the linked pages themselves. Gone now.
+    v0.14.4: ``page_links`` carries full BookStack URLs (e.g.
+    ``https://bookstack.local/books/<book>/page/<slug>``). v0.10.1's
+    ``{{@<id>}}`` syntax is gone — BookStack interprets that as
+    INCLUDE/transclusion, not as a cross-link, so the overview ended
+    up containing the inline content of every linked page instead of
+    a flat list of clickable links.
+
+    v0.14.1: stripped to pure navigation. The pre-v0.14.1 layout
+    duplicated derived information (statistics block, per-area device
+    counts) that the user could just as well read off the linked
+    pages themselves. Gone now.
 
     Output structure:
 
-    * Areas — one ``{{@<id>}}`` link per area (bare, no device counts)
-    * Bundle pages — one ``{{@<id>}}`` link per managed cross-cutting
-      page (Automations, Scripts, Network, MQTT, …)
+    * Areas — one Markdown link per area
+    * Bundle pages — one Markdown link per managed cross-cutting page
     * Unassigned devices — only present when there are any
     """
     links = page_links or {}
+
+    def link_or_bold(label: str, key: str) -> str:
+        url = links.get(key)
+        if url:
+            return f"[{_md_escape(label)}]({url})"
+        return f"**{_md_escape(label)}**"
 
     lines: list[str] = [_format_attribution(strings, now), ""]
 
     lines.extend([f"## {strings['section_areas']}", ""])
     if snapshot.areas:
-        for area in snapshot.areas:
-            page_id = links.get(f"area:{area.area_id}")
-            if page_id is not None:
-                lines.append(f"- {{{{@{page_id}}}}}")
-            else:
-                lines.append(f"- **{_md_escape(area.name)}**")
+        lines.extend(
+            f"- {link_or_bold(area.name, f'area:{area.area_id}')}"
+            for area in snapshot.areas
+        )
     else:
         lines.append(strings["empty_areas"])
 
@@ -169,47 +178,44 @@ def render_overview_auto_block(
         ("energy:_", strings["bundle_energy"]),
     )
     for key, label in bundle_links:
-        page_id = links.get(key)
-        if page_id is not None:
-            # BookStack expands ``{{@<id>}}`` server-side into a clickable
-            # link rendered with the actual page title. Plain markdown
-            # ``[label](page:id)`` doesn't work — BookStack treats
-            # ``page:id`` as a relative URL and 404s on click.
-            lines.append(f"- {{{{@{page_id}}}}}")
+        url = links.get(key)
+        if url:
+            lines.append(f"- [{_md_escape(label)}]({url})")
         else:
             lines.append(f"- {label}")
 
     if snapshot.unassigned_devices:
         lines.extend(["", f"## {strings['section_unassigned_devices']}", ""])
-        for device in snapshot.unassigned_devices:
-            page_id = links.get(f"device:{device.device_id}")
-            if page_id is not None:
-                lines.append(f"- {{{{@{page_id}}}}}")
-            else:
-                lines.append(f"- {_md_escape(device.name)}")
+        lines.extend(
+            f"- {link_or_bold(device.name, f'device:{device.device_id}')}"
+            for device in snapshot.unassigned_devices
+        )
 
     return "\n".join(lines)
 
 
 def _device_link_line(
     device: DeviceSnapshot,
-    page_links: dict[str, int],
+    page_links: dict[str, str],
 ) -> str:
     """
-    One bullet line for a device on the new minimal area page (v0.14.0).
+    One bullet line for a device on the minimal area page (v0.14.0+).
 
-    Format: ``- {{@<id>}} — Manufacturer Model`` if a BookStack page id
-    is known, falling back to ``- **Name** — Manufacturer Model``. The
-    parenthetical metadata is dropped silently when manufacturer + model
-    are both absent — most user-named devices already encode the model
-    in their name, so a trailing dash with nothing after it would be
-    pure noise.
+    Format: ``- [Name](URL) — Manufacturer Model`` if the URL is known,
+    falling back to ``- **Name** — Manufacturer Model`` when ``page_links``
+    doesn't have an entry for this device (e.g. dry-run or first sync
+    before slugs are cached). v0.14.4: switched from BookStack's
+    ``{{@<id>}}`` (which is transclusion, not link!) to plain Markdown
+    links pointing at the BookStack page URL.
+
+    The parenthetical metadata is dropped silently when manufacturer +
+    model are both absent — most user-named devices already encode the
+    model in their name, so a trailing dash with nothing after it would
+    be pure noise.
     """
-    page_id = page_links.get(f"{PAGE_KIND_DEVICE}:{device.device_id}")
-    if page_id is not None:
-        head = f"{{{{@{page_id}}}}}"
-    else:
-        head = f"**{_md_escape(device.name)}**"
+    label = _md_escape(device.name)
+    url = page_links.get(f"{PAGE_KIND_DEVICE}:{device.device_id}")
+    head = f"[{label}]({url})" if url else f"**{label}**"
     meta_bits = [bit for bit in (device.manufacturer, device.model) if bit]
     if meta_bits:
         meta = " ".join(_md_escape(bit) for bit in meta_bits)
@@ -221,18 +227,24 @@ def render_area_auto_block(
     area: AreaSnapshot,
     now: datetime,
     strings: dict[str, str],
-    page_links: dict[str, int] | None = None,
+    page_links: dict[str, str] | None = None,
 ) -> str:
     """
     Render the AUTO block of one area page.
 
     v0.14.0 reshapes this from a "full duplicate of every device card"
-    to a *navigation hub*: each device is one bullet linking to its own
-    BookStack page via ``{{@<id>}}``; automations / scripts / scenes
-    are listed by name only. The full per-device tables, entity lists,
-    network blocks, MQTT topics and stats markers live exclusively on
-    the dedicated device pages now — the area page just answers
-    "what's in this room and where do I click for details".
+    to a *navigation hub*: each device is one bullet with a Markdown link
+    to its own BookStack page; automations / scripts / scenes are listed
+    by name only. The full per-device tables, entity lists, network
+    blocks, MQTT topics and stats markers live exclusively on the
+    dedicated device pages now — the area page just answers "what's in
+    this room and where do I click for details".
+
+    v0.14.4: switched from ``{{@<id>}}`` to ``[Label](URL)`` syntax.
+    BookStack treats ``{{@<id>}}`` as INCLUDE/transclusion, not as a
+    cross-link, so the previous version inlined the entire device-page
+    content under each area's bullet. Plain Markdown links work as
+    expected.
     """
     links = page_links or {}
     lines: list[str] = [_format_attribution(strings, now), ""]

--- a/custom_components/bookstack_sync/store.py
+++ b/custom_components/bookstack_sync/store.py
@@ -36,6 +36,7 @@ class PageMapping:
     last_seen: str | None = None  # ISO timestamp of last successful sync
     tombstoned_at: str | None = None  # ISO timestamp; set when soft-deleted
     hash_origin: str = "write"  # "write" (legacy) or "bookstack" (round-trip)
+    slug: str = ""  # v0.14.4: BookStack page slug for proper Markdown URL links
 
 
 @dataclass
@@ -44,6 +45,10 @@ class StoredState:
 
     pages: dict[str, PageMapping] = field(default_factory=dict)
     chapters: dict[str, int] = field(default_factory=dict)
+    # v0.14.4: BookStack book slug, captured once at sync start so the
+    # renderers can build full ``/books/<book-slug>/page/<page-slug>``
+    # URLs for the overview / area cross-references.
+    book_slug: str = ""
 
 
 class BookStackSyncStore:
@@ -72,8 +77,9 @@ class BookStackSyncStore:
         raw = await self._store.async_load() or {}
         pages_raw = raw.get("pages", {}) or {}
         chapters_raw = raw.get("chapters", {}) or {}
-        # Migration: pre-v0.11 storage doesn't have ``hash_origin``.
-        # Drop unknown fields gracefully (forward-compat too).
+        # Migration: pre-v0.11 storage doesn't have ``hash_origin``;
+        # pre-v0.14.4 doesn't have ``slug``. Drop unknown fields
+        # gracefully (forward-compat too).
         known_fields = set(PageMapping.__dataclass_fields__)
         pages: dict[str, PageMapping] = {}
         for key, value in pages_raw.items():
@@ -82,6 +88,7 @@ class BookStackSyncStore:
         self._state = StoredState(
             pages=pages,
             chapters={key: int(value) for key, value in chapters_raw.items()},
+            book_slug=str(raw.get("book_slug") or ""),
         )
         self._loaded = True
 
@@ -93,6 +100,7 @@ class BookStackSyncStore:
                     key: asdict(value) for key, value in self._state.pages.items()
                 },
                 "chapters": dict(self._state.chapters),
+                "book_slug": self._state.book_slug,
             },
         )
 
@@ -119,3 +127,11 @@ class BookStackSyncStore:
     def all_chapters(self) -> dict[str, int]:
         """Return a shallow copy of the persisted chapter map."""
         return dict(self._state.chapters)
+
+    def get_book_slug(self) -> str:
+        """Return the BookStack book slug, empty string if not yet known."""
+        return self._state.book_slug
+
+    def set_book_slug(self, slug: str) -> None:
+        """Persist the BookStack book slug for URL construction."""
+        self._state.book_slug = slug

--- a/custom_components/bookstack_sync/sync.py
+++ b/custom_components/bookstack_sync/sync.py
@@ -342,13 +342,29 @@ def _plan_pages(
     return planned
 
 
+def _build_page_url(base_url: str, book_slug: str, page_slug: str) -> str | None:
+    """
+    Construct a full BookStack URL for a page.
+
+    Returns ``None`` when any component is missing — caller falls back
+    to a bold-name label rather than rendering a broken link. Empty
+    ``book_slug`` typically means the post-v0.14.4 first sync hasn't
+    finished caching the slug yet; empty ``page_slug`` means the
+    mapping was migrated from a pre-v0.14.4 store and we haven't
+    re-fetched the page since.
+    """
+    if not base_url or not book_slug or not page_slug:
+        return None
+    return f"{base_url.rstrip('/')}/books/{book_slug}/page/{page_slug}"
+
+
 def _plan_area_pages(
     snapshot: HASnapshot,
     now: datetime,
     strings: dict[str, str],
-    page_links: dict[str, int],
+    page_links: dict[str, str],
 ) -> list[_PlannedPage]:
-    """Render area pages with ``{{@<id>}}`` cross-links to device pages (v0.14.0)."""
+    """Render area pages with cross-page Markdown links to device pages."""
     return [
         _PlannedPage(
             key=f"{PAGE_KIND_AREA}:{area.area_id}",
@@ -430,10 +446,42 @@ async def run_sync(  # noqa: PLR0912, PLR0913, PLR0915 - cohesive 3-pass entry p
         {} if dry_run else await _ensure_chapters(client, store, book_id, strings)
     )
 
-    # Pass 1: sync devices + bundles. Collect IDs so areas + overview can
-    # cross-link them via BookStack's ``{{@<id>}}`` syntax.
-    page_ids: dict[str, int] = {}
-    area_planned = _plan_area_pages(snapshot, now, strings, page_ids)
+    # v0.14.4: capture (and persist) the BookStack book slug so we can
+    # build proper Markdown links of the form
+    # ``{base_url}/books/{book_slug}/page/{page_slug}`` instead of the
+    # ``{{@<id>}}`` syntax we used through v0.14.3 — which BookStack
+    # interprets as INCLUDE/transclusion (it inlines the linked page's
+    # whole content), not as a cross-link.
+    base_url = client.base_url
+    book_slug = store.get_book_slug()
+    if not book_slug:
+        try:
+            for book in await client.list_books():
+                if int(book.get("id", 0)) == book_id:
+                    book_slug = str(book.get("slug") or "")
+                    break
+        except BookStackApiError as err:
+            LOGGER.warning(
+                "Could not fetch book slug for URL construction: %s. "
+                "Falling back to bold-name labels in cross-references.",
+                err,
+            )
+        if book_slug:
+            store.set_book_slug(book_slug)
+
+    # Pass 1: sync devices + bundles. Build URL map so areas + overview can
+    # render proper Markdown links to them.
+    page_links: dict[str, str] = {}
+
+    def _refresh_url(page_key: str) -> None:
+        """Look up the current slug in the store and add the URL to page_links."""
+        m = store.get(page_key)
+        if m and m.slug:
+            url = _build_page_url(base_url, book_slug, m.slug)
+            if url:
+                page_links[page_key] = url
+
+    area_planned = _plan_area_pages(snapshot, now, strings, page_links)
     total_steps = len(planned) + len(area_planned) + 1  # +1 for the overview
     step = 0
     for page in planned:
@@ -453,7 +501,7 @@ async def run_sync(  # noqa: PLR0912, PLR0913, PLR0915 - cohesive 3-pass entry p
                 force=force,
             )
             if page_id is not None:
-                page_ids[page.key] = page_id
+                _refresh_url(page.key)
         except BookStackApiAuthError:
             raise
         except BookStackApiError as err:
@@ -465,10 +513,10 @@ async def run_sync(  # noqa: PLR0912, PLR0913, PLR0915 - cohesive 3-pass entry p
         if not dry_run:
             await asyncio.sleep(WRITE_PAUSE_SECONDS)
 
-    # Pass 2: render area pages (now that device IDs exist) and sync them.
-    # Re-plan with the populated page_ids so each area's auto-body
-    # contains real cross-links instead of bold-name fallbacks.
-    area_planned = _plan_area_pages(snapshot, now, strings, page_ids)
+    # Pass 2: render area pages (now that device URLs exist) and sync them.
+    # Re-plan with the populated page_links so each area's auto-body
+    # contains real cross-page Markdown links instead of bold-name fallbacks.
+    area_planned = _plan_area_pages(snapshot, now, strings, page_links)
     for page in area_planned:
         step += 1
         try:
@@ -486,7 +534,7 @@ async def run_sync(  # noqa: PLR0912, PLR0913, PLR0915 - cohesive 3-pass entry p
                 force=force,
             )
             if page_id is not None:
-                page_ids[page.key] = page_id
+                _refresh_url(page.key)
         except BookStackApiAuthError:
             raise
         except BookStackApiError as err:
@@ -498,7 +546,7 @@ async def run_sync(  # noqa: PLR0912, PLR0913, PLR0915 - cohesive 3-pass entry p
         if not dry_run:
             await asyncio.sleep(WRITE_PAUSE_SECONDS)
 
-    # Pass 3: render overview with the full page-link map + sync it.
+    # Pass 3: render overview with the full URL map + sync it.
     overview = _PlannedPage(
         key=f"{PAGE_KIND_OVERVIEW}:_",
         title=strings["title_overview"],
@@ -506,7 +554,7 @@ async def run_sync(  # noqa: PLR0912, PLR0913, PLR0915 - cohesive 3-pass entry p
             snapshot,
             now,
             strings,
-            page_links=page_ids,
+            page_links=page_links,
         ),
     )
     try:
@@ -647,6 +695,7 @@ async def _sync_one(  # noqa: PLR0913 - cohesive sync step, splitting hurts clar
                 auto_block_hash=saved_hash,
                 last_seen=datetime.now(tz=UTC).isoformat(),
                 hash_origin=hash_origin,
+                slug=str(created.get("slug") or ""),
             ),
         )
         report.created.append(page.title)
@@ -690,6 +739,7 @@ async def _sync_one(  # noqa: PLR0913 - cohesive sync step, splitting hurts clar
                 last_seen=mapping.last_seen,
                 tombstoned_at=mapping.tombstoned_at,
                 hash_origin="bookstack",
+                slug=str(existing.get("slug") or "") or mapping.slug,
             )
             store.set(page.key, mapping)
         elif mapping.hash_origin != "bookstack":
@@ -745,6 +795,12 @@ async def _sync_one(  # noqa: PLR0913 - cohesive sync step, splitting hurts clar
         # always re-write once to settle into the new regime.
         report.unchanged.append(page.title)
         mapping.last_seen = datetime.now(tz=UTC).isoformat()
+        # v0.14.4: refresh slug from BookStack — handles the case where
+        # a user renamed the page in BookStack and BookStack regenerated
+        # the slug. Without this update, our cross-page links would 404.
+        live_slug = str(existing.get("slug") or "")
+        if live_slug:
+            mapping.slug = live_slug
         store.set(page.key, mapping)
         return mapping.page_id
 
@@ -768,6 +824,7 @@ async def _sync_one(  # noqa: PLR0913 - cohesive sync step, splitting hurts clar
             last_seen=datetime.now(tz=UTC).isoformat(),
             tombstoned_at=None,  # device is back; clear any prior tombstone
             hash_origin=hash_origin,
+            slug=str(saved.get("slug") or "") or mapping.slug,
         ),
     )
     report.updated.append(page.title)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -257,10 +257,11 @@ class TestOverviewLinks:
     ) -> None:
         """v0.14.1 invariant: overview = pure navigation, no derived data.
 
-        Specifically: no ``Statistik`` block, no per-area device counts,
-        no aggregated totals. Just cross-page links to areas + bundle
-        pages + (when present) unassigned devices.
+        v0.14.4: cross-references are now plain Markdown links pointing
+        at the BookStack page URL, not the ``{{@<id>}}`` template
+        (which BookStack treats as include/transclusion).
         """
+        url = "http://bookstack.local/books/book/page/lr"
         snap = _empty_snapshot()
         snap.areas.append(
             AreaSnapshot(
@@ -273,24 +274,29 @@ class TestOverviewLinks:
             snap,
             fixed_now,
             strings_de,
-            page_links={"area:lr": 42},
+            page_links={"area:lr": url},
         )
-        # Navigation links present.
-        assert "{{@42}}" in out
+        # Navigation link present in Markdown form.
+        assert f"[Living Room]({url})" in out
         # No statistics anywhere.
         assert "Statistik" not in out
-        assert "**3**" not in out  # the old per-area device count
-        assert "Geräte" not in out.split("## Räume")[0]  # nothing before areas
-        # Per-area device count gone — the bullet is the bare link only.
+        assert "**3**" not in out
+        assert "Geräte" not in out.split("## Räume")[0]
+        # Bare link, no per-area device count appended.
         for line in out.splitlines():
-            if line.startswith("- {{@42}}"):
-                assert line == "- {{@42}}", f"area bullet should be bare link: {line!r}"
+            if line.startswith(f"- [Living Room]({url})"):
+                assert line == f"- [Living Room]({url})", (
+                    f"area bullet should be bare link: {line!r}"
+                )
+        # And the deprecated transclusion syntax must not appear.
+        assert "{{@" not in out
 
-    def test_area_link_rendered(
+    def test_area_link_rendered_as_markdown_link(
         self,
         fixed_now: datetime,
         strings_de: dict[str, str],
     ) -> None:
+        url = "http://bookstack.local/books/book/page/living"
         area = AreaSnapshot(area_id="living", name="Living Room")
         snap = _empty_snapshot()
         snap.areas.append(area)
@@ -298,10 +304,11 @@ class TestOverviewLinks:
             snap,
             fixed_now,
             strings_de,
-            page_links={"area:living": 42},
+            page_links={"area:living": url},
         )
-        # BookStack-internal cross-link syntax — server expands {{@N}}.
-        assert "{{@42}}" in out
+        # v0.14.4: plain Markdown link, not {{@id}} include syntax.
+        assert f"[Living Room]({url})" in out
+        assert "{{@" not in out
 
     def test_area_falls_back_to_bold_when_no_link(
         self,
@@ -314,46 +321,49 @@ class TestOverviewLinks:
         out = render_overview_auto_block(snap, fixed_now, strings_de)
         assert "**Living Room**" in out
         assert "{{@" not in out
+        assert "](http" not in out  # no link rendered without URL in map
 
-    def test_bundle_links_rendered(
+    def test_bundle_links_rendered_as_markdown(
         self,
         fixed_now: datetime,
         strings_en: dict[str, str],
     ) -> None:
         snap = _empty_snapshot()
+        urls = {
+            "integrations:_": "http://b/books/book/page/int",
+            "automations:_": "http://b/books/book/page/auto",
+            "scripts:_": "http://b/books/book/page/scr",
+            "scenes:_": "http://b/books/book/page/scn",
+            "addons:_": "http://b/books/book/page/add",
+        }
         out = render_overview_auto_block(
             snap,
             fixed_now,
             strings_en,
-            page_links={
-                "integrations:_": 1,
-                "automations:_": 2,
-                "scripts:_": 3,
-                "scenes:_": 4,
-                "addons:_": 5,
-            },
+            page_links=urls,
         )
-        assert "{{@1}}" in out
-        assert "{{@2}}" in out
-        assert "{{@3}}" in out
-        assert "{{@4}}" in out
-        assert "{{@5}}" in out
+        for url in urls.values():
+            assert f"]({url})" in out
+        assert "{{@" not in out
 
-    def test_no_legacy_page_link_syntax_anywhere(
+    def test_no_legacy_or_transclusion_syntax_anywhere(
         self,
         fixed_now: datetime,
         strings_de: dict[str, str],
     ) -> None:
-        """
-        Regression #55: never emit ``](page:`` anywhere in any rendered page.
+        """v0.14.4: never emit ``{{@<id>}}`` (transclusion!) or ``](page:``.
 
-        The naïve markdown link form ``[label](page:42)`` is treated by
-        BookStack as a relative URL ``page:42`` and 404s on click. The
-        correct format is the BookStack server-side template
-        ``{{@42}}``. This test calls every ``render_*_auto_block`` we
-        ship and asserts the bad pattern never appears.
+        Both are bug histories: ``[label](page:N)`` 404s (issue #55 in
+        v0.10.0), ``{{@<id>}}`` causes BookStack to inline-include the
+        linked page's whole content (the user-visible misbehaviour
+        leading to v0.14.4). The correct form is plain Markdown
+        ``[label](https://bookstack.../books/<book>/page/<slug>)``.
         """
-        # Exercise a snapshot with all the page-link entry-points populated.
+        url_a = "http://b/books/book/page/wz"
+        url_d = "http://b/books/book/page/dev1"
+        url_unassigned = "http://b/books/book/page/unassigned"
+        url_int = "http://b/books/book/page/int"
+
         area = AreaSnapshot(area_id="living", name="Wohnzimmer")
         snap = _empty_snapshot()
         snap.areas.append(area)
@@ -365,16 +375,17 @@ class TestOverviewLinks:
                 fixed_now,
                 strings_de,
                 page_links={
-                    "integrations:_": 1,
-                    "automations:_": 2,
-                    "scripts:_": 3,
-                    "scenes:_": 4,
-                    "addons:_": 5,
-                    "area:living": 99,
-                    "device:dev1": 100,
+                    "integrations:_": url_int,
+                    "area:living": url_a,
+                    "device:dev1": url_unassigned,
                 },
             ),
-            render_area_auto_block(area, fixed_now, strings_de),
+            render_area_auto_block(
+                area,
+                fixed_now,
+                strings_de,
+                page_links={"device:dev1": url_d},
+            ),
             render_device_auto_block(
                 _device(name="Plain Device"),
                 fixed_now,
@@ -383,22 +394,20 @@ class TestOverviewLinks:
         ]
         for out in outputs:
             assert "](page:" not in out, (
-                f"legacy [label](page:N) syntax found in output: {out[:200]!r}"
+                f"legacy [label](page:N) syntax found: {out[:200]!r}"
             )
+            assert "{{@" not in out, f"transclusion syntax found: {out[:200]!r}"
 
     def test_special_chars_in_area_name_escaped_when_no_link(
         self,
         fixed_now: datetime,
         strings_de: dict[str, str],
     ) -> None:
-        # When a page-link IS available, BookStack's ``{{@id}}`` expands
-        # to the page title server-side — our custom label is dropped.
-        # When NO page-link exists we fall back to ``**escaped_label**``
-        # — and that path must still escape special chars.
+        """Fall-back path (no URL) must escape special chars in the bold label."""
         area = AreaSnapshot(area_id="living", name="Wohn|zimmer <stage>")
         snap = _empty_snapshot()
         snap.areas.append(area)
-        out = render_overview_auto_block(snap, fixed_now, strings_de)  # no links
+        out = render_overview_auto_block(snap, fixed_now, strings_de)
         assert r"Wohn\|zimmer &lt;stage&gt;" in out
 
 
@@ -863,17 +872,18 @@ class TestAreaPageMinimal:
         fixed_now: datetime,
         strings_de: dict[str, str],
     ) -> None:
-        """Devices appear as ``- {{@<id>}} — Manufacturer Model`` lines."""
-        # _device defaults: manufacturer="Acme", model="Model X"
+        """v0.14.4: devices appear as ``- [Name](URL) — Manufacturer Model``."""
+        url = "http://bookstack.local/books/book/page/bm-gang"
         device = _device("abc", name="Bewegungsmelder Gang")
         area = AreaSnapshot(area_id="hall", name="Gang", devices=[device])
         out = render_area_auto_block(
             area,
             fixed_now,
             strings_de,
-            page_links={"device:abc": 142},
+            page_links={"device:abc": url},
         )
-        assert "- {{@142}} — Acme Model X" in out
+        assert f"- [Bewegungsmelder Gang]({url}) — Acme Model X" in out
+        assert "{{@" not in out
 
     def test_device_falls_back_to_bold_name_when_no_link(
         self,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -36,8 +36,13 @@ def _fake_client_with_state(state: dict[str, Any]) -> MagicMock:
     state.setdefault("pages", {})  # id -> {markdown, chapter_id, name}
     state.setdefault("chapters", {})  # id -> name
     state.setdefault("next_id", 100)
+    state.setdefault("books", [{"id": 1, "name": "Book", "slug": "book"}])
 
     client = MagicMock()
+    client.base_url = "http://bookstack.local"
+
+    async def list_books() -> list[dict[str, Any]]:
+        return list(state["books"])
 
     async def list_chapters(book_id: int) -> list[dict[str, Any]]:
         return [{"id": cid, "name": name} for cid, name in state["chapters"].items()]
@@ -65,6 +70,7 @@ def _fake_client_with_state(state: dict[str, Any]) -> MagicMock:
         state["pages"][pid] = {
             "id": pid,
             "name": name,
+            "slug": f"slug-{pid}",
             "markdown": markdown,
             "chapter_id": chapter_id,
             "book_id": book_id,
@@ -91,6 +97,7 @@ def _fake_client_with_state(state: dict[str, Any]) -> MagicMock:
             state["pages"][page_id]["tags"] = tags
         return state["pages"][page_id]
 
+    client.list_books = AsyncMock(side_effect=list_books)
     client.list_chapters = AsyncMock(side_effect=list_chapters)
     client.create_chapter = AsyncMock(side_effect=create_chapter)
     client.create_page = AsyncMock(side_effect=create_page)


### PR DESCRIPTION
## Summary

- Diagnosed the overview-page bug: BookStack's ``{{@id}}`` is INCLUDE/transclusion, not a hyperlink, so the overview was inlining the full content of every area page instead of linking to it.
- Replaced every cross-page reference in the renderer with plain Markdown ``[Label](http://host/books/<book>/page/<page>)`` links — works as navigation in BookStack and as clickable links in exported ``.md`` files.
- Added ``slug`` to ``PageMapping`` and ``book_slug`` to ``StoredState``; both populate lazily on the next sync. Cross-links degrade to ``**bold**`` labels until slugs are captured. Existing entries migrate transparently.

## Test plan

- [x] ``ruff check`` and ``ruff format --check`` clean.
- [x] 178 unit tests pass on Python 3.14 (WSL).
- [x] New tests assert Markdown URL format on overview, area, and bundle renderings.
- [x] Negative test forbids any remaining ``{{@`` literal in rendered markup.
- [ ] After merge: smoke-test on the Pi instance with ``force: true`` to overwrite the v0.14.0/v0.14.1 reshape and the new link syntax in one pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)