### PR TITLE
V0.14.5: HA-frontend deep-links + friendly integration names on device pages

### DIFF
--- a/custom_components/bookstack_sync/_strings.py
+++ b/custom_components/bookstack_sync/_strings.py
@@ -195,6 +195,9 @@ _STRINGS: dict[str, dict[str, str]] = {
         "integration_col_entities": "Entities",
         "integration_col_docs": "Doku",
         "integration_docs_link_label": "Doku",
+        # HA-Frontend deep-links (v0.14.5+)
+        "link_open_in_ha": "In Home Assistant öffnen",
+        "link_helpers_in_ha": "Helper-Konfiguration in Home Assistant öffnen",
         # Entity-line bits
         "entity_state_label": "State",
         "entity_topic_label": "Topic",
@@ -380,6 +383,8 @@ _STRINGS: dict[str, dict[str, str]] = {
         "integration_col_entities": "Entities",
         "integration_col_docs": "Docs",
         "integration_docs_link_label": "Docs",
+        "link_open_in_ha": "Open in Home Assistant",
+        "link_helpers_in_ha": "Open helper configuration in Home Assistant",
         "entity_state_label": "State",
         "entity_topic_label": "Topic",
         "entity_disabled_marker": "_[disabled]_",

--- a/custom_components/bookstack_sync/extractor.py
+++ b/custom_components/bookstack_sync/extractor.py
@@ -84,6 +84,23 @@ class NetworkInfo:
     source_platform: str | None = None  # "unifi", "device_tracker", "registry"
 
 
+@dataclass(frozen=True)
+class DeviceIntegrationRef:
+    """
+    A device's link to one config entry (= one installed integration).
+
+    Carries both ``entry_id`` (stable HA-internal handle) and ``domain``
+    (human-readable, also what HA uses in its frontend URL
+    ``/config/integrations/integration/<domain>``). v0.14.5 introduced
+    this so the device page can render the friendly domain name and a
+    deep-link instead of the ULID-style entry_id that pre-v0.14.5 builds
+    accidentally exposed in the Stammdaten table.
+    """
+
+    entry_id: str
+    domain: str
+
+
 @dataclass
 class DeviceSnapshot:
     """One Home Assistant device with its entity list."""
@@ -95,7 +112,7 @@ class DeviceSnapshot:
     sw_version: str | None
     hw_version: str | None
     area_id: str | None
-    config_entries: tuple[str, ...]
+    config_entries: tuple[DeviceIntegrationRef, ...]
     entities: list[EntitySnapshot] = field(default_factory=list)
     # Primary network identity for this device. ``network_extra`` lists
     # additional concurrent connections (e.g. NUC plugged in via both
@@ -307,6 +324,15 @@ def extract_snapshot(  # noqa: PLR0912, PLR0915 - cohesive registry walk
         if area.id not in excluded
     }
 
+    # v0.14.5: pre-resolve entry_id -> domain so DeviceSnapshot.config_entries
+    # can carry both. Pre-v0.14.5 the device's ``Integrationen`` cell
+    # accidentally rendered ULID-style entry_ids; users want the friendly
+    # domain plus a clickable deep-link to
+    # ``/config/integrations/integration/<domain>``.
+    entry_domains = {
+        entry.entry_id: entry.domain for entry in hass.config_entries.async_entries()
+    }
+
     devices: dict[str, DeviceSnapshot] = {}
     for device in device_reg.devices.values():
         if device.area_id in excluded:
@@ -317,6 +343,16 @@ def extract_snapshot(  # noqa: PLR0912, PLR0915 - cohesive registry walk
         display_name = device.name_by_user or device.name
         if not display_name:
             continue
+        device_refs = tuple(
+            DeviceIntegrationRef(
+                entry_id=eid,
+                # Fallback to entry_id for the rare orphan case where a
+                # device still references an entry that's already gone
+                # from hass.config_entries — better than crashing.
+                domain=entry_domains.get(eid, eid),
+            )
+            for eid in sorted(device.config_entries)
+        )
         devices[device.id] = DeviceSnapshot(
             device_id=device.id,
             name=display_name,
@@ -325,7 +361,7 @@ def extract_snapshot(  # noqa: PLR0912, PLR0915 - cohesive registry walk
             sw_version=device.sw_version,
             hw_version=device.hw_version,
             area_id=device.area_id,
-            config_entries=tuple(sorted(device.config_entries)),
+            config_entries=device_refs,
         )
 
     orphan_entities_by_area: dict[str, list[EntitySnapshot]] = {}
@@ -561,6 +597,8 @@ def _extract_integrations(
 ) -> list[IntegrationSnapshot]:
     devices_per_entry: dict[str, int] = {}
     for device in device_reg.devices.values():
+        # device_reg's devices iterate the raw HA registry here (not our
+        # filtered DeviceSnapshots), so the values are still entry_id strings.
         for entry_id in device.config_entries:
             devices_per_entry[entry_id] = devices_per_entry.get(entry_id, 0) + 1
 

--- a/custom_components/bookstack_sync/manifest.json
+++ b/custom_components/bookstack_sync/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dibi73/ha-bookstack-sync/issues",
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.14.4"
+  "version": "0.14.5"
 }

--- a/custom_components/bookstack_sync/renderer.py
+++ b/custom_components/bookstack_sync/renderer.py
@@ -96,6 +96,101 @@ def _md_escape(value: str) -> str:
     )
 
 
+# ---------------------------------------------------------------------------
+# HA-Frontend deep-links (v0.14.5+)
+# ---------------------------------------------------------------------------
+# Every renderer that emits an object the user might want to inspect or edit
+# in the live HA UI takes a ``ha_url`` parameter (default ``""``). When set,
+# objects link out to the canonical config / dev-tools paths; when empty,
+# they degrade silently to plain code spans / bold labels — never a broken
+# href. The base URL is resolved once in sync.py from
+# ``hass.config.external_url or hass.config.internal_url`` and threaded down.
+
+
+_HA_FIXED_PATHS = {"helpers": "/config/helpers"}
+_HA_OBJECT_PATHS = {
+    "area": "/config/areas/area/{id}",
+    "device": "/config/devices/device/{id}",
+    "integration": "/config/integrations/integration/{id}",
+    "entity": "/developer-tools/state?entity_id={id}",
+}
+_HA_EDIT_KINDS = {"automation", "script", "scene"}
+
+
+def _ha_url_for(ha_url: str, kind: str, identifier: str) -> str:
+    """
+    Build a Home Assistant frontend URL for one object.
+
+    Returns ``""`` when no base URL is known, the kind is unrecognised, or
+    the identifier is empty — callers must check and fall back accordingly.
+
+    Path conventions (HA stable as of 2026.5):
+
+    * ``area``       → ``/config/areas/area/<area_id>``
+    * ``device``     → ``/config/devices/device/<device_id>``
+    * ``automation`` → ``/config/automation/edit/<entity_id_suffix>``
+    * ``script``     → ``/config/script/edit/<entity_id_suffix>``
+    * ``scene``      → ``/config/scene/edit/<entity_id_suffix>``
+    * ``integration``→ ``/config/integrations/integration/<domain>``
+    * ``entity``     → ``/developer-tools/state?entity_id=<entity_id>``
+    * ``helpers``    → ``/config/helpers`` (no per-helper deep-link;
+                       identifier is ignored)
+
+    For automation / script / scene the identifier is the bare entity_id;
+    we strip the domain prefix so callers can pass either form.
+    """
+    if not ha_url or not kind:
+        return ""
+    fixed = _HA_FIXED_PATHS.get(kind)
+    if fixed is not None:
+        return f"{ha_url}{fixed}"
+    if not identifier:
+        return ""
+    object_path = _HA_OBJECT_PATHS.get(kind)
+    if object_path is not None:
+        return f"{ha_url}{object_path.format(id=identifier)}"
+    if kind in _HA_EDIT_KINDS:
+        suffix = identifier.split(".", 1)[1] if "." in identifier else identifier
+        return f"{ha_url}/config/{kind}/edit/{suffix}"
+    return ""
+
+
+def _ha_open_line(
+    ha_url: str,
+    kind: str,
+    identifier: str,
+    strings: dict[str, str],
+) -> list[str]:
+    """
+    Return ``[link, ""]`` ready to extend into a body, or ``[]`` if no URL.
+
+    Used at the top of single-object pages (device, area) right after the
+    attribution line. Empty list when ``ha_url`` is unset keeps pre-config
+    setups producing valid Markdown without dangling labels.
+    """
+    url = _ha_url_for(ha_url, kind, identifier)
+    if not url:
+        return []
+    label = _md_escape(strings["link_open_in_ha"])
+    return [f"[{label}]({url})", ""]
+
+
+def _entity_id_md(entity_id: str, ha_url: str) -> str:
+    r"""
+    Render an entity_id as a clickable code-span when ``ha_url`` is set.
+
+    Plain ``\`button.foo\``` becomes
+    ``[\`button.foo\`](http://.../developer-tools/state?entity_id=button.foo)``.
+    Without ``ha_url`` the bare code-span is returned unchanged so existing
+    layouts stay byte-identical until the user sets ``external_url``.
+    """
+    code = f"`{entity_id}`"
+    url = _ha_url_for(ha_url, "entity", entity_id)
+    if not url:
+        return code
+    return f"[{code}]({url})"
+
+
 def render_tombstone_auto_block(strings: dict[str, str], now: datetime) -> str:
     """Render the AUTO block for a page whose HA object no longer exists."""
     attribution = strings["tombstone_attribution_template"].format(
@@ -228,6 +323,7 @@ def render_area_auto_block(
     now: datetime,
     strings: dict[str, str],
     page_links: dict[str, str] | None = None,
+    ha_url: str = "",
 ) -> str:
     """
     Render the AUTO block of one area page.
@@ -248,6 +344,7 @@ def render_area_auto_block(
     """
     links = page_links or {}
     lines: list[str] = [_format_attribution(strings, now), ""]
+    lines.extend(_ha_open_line(ha_url, "area", area.area_id, strings))
 
     lines.extend(
         [
@@ -269,7 +366,7 @@ def render_area_auto_block(
                 "",
                 f"## {strings['section_orphan_entities']}",
                 "",
-                *_entity_lines(area.orphan_entities, strings),
+                *_entity_lines(area.orphan_entities, strings, ha_url),
             ],
         )
 
@@ -284,7 +381,7 @@ def render_area_auto_block(
                 "",
             ],
         )
-        lines.extend(f"- {_md_escape(a.name)}" for a in area.automations)
+        lines.extend(_area_automation_line(a, ha_url) for a in area.automations)
 
     if area.scripts:
         lines.extend(
@@ -297,7 +394,7 @@ def render_area_auto_block(
                 "",
             ],
         )
-        lines.extend(f"- {_md_escape(s.name)}" for s in area.scripts)
+        lines.extend(_area_script_line(s, ha_url) for s in area.scripts)
 
     if area.scenes:
         lines.extend(
@@ -310,11 +407,21 @@ def render_area_auto_block(
                 "",
             ],
         )
-        lines.extend(
-            f"- **{_md_escape(s.name)}** – `{s.entity_id}`" for s in area.scenes
-        )
+        lines.extend(_scene_line(s, ha_url) for s in area.scenes)
 
     return "\n".join(lines).rstrip() + "\n"
+
+
+def _area_automation_line(auto: AutomationSnapshot, ha_url: str) -> str:
+    name_md = _md_escape(auto.name)
+    edit_url = _ha_url_for(ha_url, "automation", auto.entity_id)
+    return f"- [{name_md}]({edit_url})" if edit_url else f"- {name_md}"
+
+
+def _area_script_line(script: ScriptSnapshot, ha_url: str) -> str:
+    name_md = _md_escape(script.name)
+    edit_url = _ha_url_for(ha_url, "script", script.entity_id)
+    return f"- [{name_md}]({edit_url})" if edit_url else f"- {name_md}"
 
 
 def render_device_auto_block(
@@ -322,20 +429,26 @@ def render_device_auto_block(
     now: datetime,
     strings: dict[str, str],
     reverse_usage: dict[str, list[ReverseUsageEntry]] | None = None,
+    ha_url: str = "",
 ) -> str:
     """Render the AUTO block of one device page."""
     lines: list[str] = [
         _format_attribution(strings, now),
         "",
-        f"## {strings['section_master_data']}",
-        "",
-        _device_facts_table(device, strings),
     ]
+    lines.extend(_ha_open_line(ha_url, "device", device.device_id, strings))
+    lines.extend(
+        [
+            f"## {strings['section_master_data']}",
+            "",
+            _device_facts_table(device, strings, ha_url),
+        ],
+    )
     if device.network is not None:
         lines.extend(_network_section(device, strings))
     lines.extend(["", f"## {strings['section_entities']}", ""])
     if device.entities:
-        lines.extend(_entity_lines(device.entities, strings))
+        lines.extend(_entity_lines(device.entities, strings, ha_url))
     else:
         lines.append(strings["empty_entities_in_device"])
     if reverse_usage:
@@ -513,6 +626,7 @@ def render_automations_auto_block(
     automations: list[AutomationSnapshot],
     now: datetime,
     strings: dict[str, str],
+    ha_url: str = "",
 ) -> str:
     """Render the AUTO block listing every HA automation."""
     lines: list[str] = [
@@ -529,7 +643,7 @@ def render_automations_auto_block(
         return "\n".join(lines).rstrip() + "\n"
 
     for auto in automations:
-        lines.extend(_automation_block(auto, strings))
+        lines.extend(_automation_block(auto, strings, ha_url))
     return "\n".join(lines).rstrip() + "\n"
 
 
@@ -537,6 +651,7 @@ def render_scripts_auto_block(
     scripts: list[ScriptSnapshot],
     now: datetime,
     strings: dict[str, str],
+    ha_url: str = "",
 ) -> str:
     """Render the AUTO block listing every HA script."""
     lines: list[str] = [
@@ -550,7 +665,7 @@ def render_scripts_auto_block(
         return "\n".join(lines).rstrip() + "\n"
 
     for script in scripts:
-        lines.extend(_script_block(script, strings))
+        lines.extend(_script_block(script, strings, ha_url))
     return "\n".join(lines).rstrip() + "\n"
 
 
@@ -558,6 +673,7 @@ def render_scenes_auto_block(
     scenes: list[SceneSnapshot],
     now: datetime,
     strings: dict[str, str],
+    ha_url: str = "",
 ) -> str:
     """Render the AUTO block listing every HA scene."""
     lines: list[str] = [
@@ -570,14 +686,22 @@ def render_scenes_auto_block(
         lines.append(strings["empty_scenes"])
         return "\n".join(lines).rstrip() + "\n"
 
-    lines.extend(f"- **{_md_escape(s.name)}** – `{s.entity_id}`" for s in scenes)
+    lines.extend(_scene_line(s, ha_url) for s in scenes)
     return "\n".join(lines).rstrip() + "\n"
+
+
+def _scene_line(scene: SceneSnapshot, ha_url: str) -> str:
+    name_md = _md_escape(scene.name)
+    edit_url = _ha_url_for(ha_url, "scene", scene.entity_id)
+    head = f"[**{name_md}**]({edit_url})" if edit_url else f"**{name_md}**"
+    return f"- {head} – {_entity_id_md(scene.entity_id, ha_url)}"
 
 
 def render_integrations_auto_block(
     integrations: list[IntegrationSnapshot],
     now: datetime,
     strings: dict[str, str],
+    ha_url: str = "",
 ) -> str:
     """Render the AUTO block listing every installed integration / config entry."""
     lines: list[str] = [
@@ -608,8 +732,10 @@ def render_integrations_auto_block(
         docs_cell = (
             f"[{docs_label}]({i.documentation_url})" if i.documentation_url else "—"
         )
+        domain_url = _ha_url_for(ha_url, "integration", i.domain)
+        domain_cell = f"[`{i.domain}`]({domain_url})" if domain_url else f"`{i.domain}`"
         lines.append(
-            f"| `{i.domain}` | {_md_escape(i.title)} | {i.state} | {i.source} "
+            f"| {domain_cell} | {_md_escape(i.title)} | {i.state} | {i.source} "
             f"| {i.device_count} | {i.entity_count} | {docs_cell} |",
         )
     return "\n".join(lines).rstrip() + "\n"
@@ -757,22 +883,43 @@ def render_network_auto_block(  # noqa: PLR0912, PLR0913, PLR0915 - cohesive ren
     return "\n".join(lines).rstrip() + "\n"
 
 
-def _device_facts_table(device: DeviceSnapshot, strings: dict[str, str]) -> str:
+def _device_facts_table(
+    device: DeviceSnapshot,
+    strings: dict[str, str],
+    ha_url: str = "",
+) -> str:
+    integrations_cell = (
+        _integrations_cell(device, ha_url) if device.config_entries else "—"
+    )
     rows = [
         (strings["field_manufacturer"], _md_escape(device.manufacturer or "—")),
         (strings["field_model"], _md_escape(device.model or "—")),
         (strings["field_firmware"], _md_escape(device.sw_version or "—")),
         (strings["field_hardware"], _md_escape(device.hw_version or "—")),
-        (
-            strings["field_integrations"],
-            _md_escape(", ".join(device.config_entries) or "—"),
-        ),
+        (strings["field_integrations"], integrations_cell),
         (strings["field_device_id"], device.device_id),
     ]
     header = f"| {strings['table_field_header']} | {strings['table_value_header']} |"
     out = [header, "| --- | --- |"]
     out.extend(f"| {key} | {value} |" for key, value in rows)
     return "\n".join(out)
+
+
+def _integrations_cell(device: DeviceSnapshot, ha_url: str) -> str:
+    """
+    Render the device's ``Integrationen`` cell as comma-separated domain names.
+
+    Pre-v0.14.5 this accidentally joined ULID-style entry_ids
+    (``01JK17JC46PYGDD6AABQTMKGKX``); v0.14.5 carries the resolved domain
+    name on each ``DeviceIntegrationRef`` and additionally deep-links to
+    ``/config/integrations/integration/<domain>`` when ``ha_url`` is set.
+    """
+    parts: list[str] = []
+    for ref in device.config_entries:
+        domain = _md_escape(ref.domain)
+        url = _ha_url_for(ha_url, "integration", ref.domain)
+        parts.append(f"[{domain}]({url})" if url else domain)
+    return ", ".join(parts)
 
 
 _STATE_CLASS_LONG_TERM_STATS = frozenset(
@@ -783,13 +930,14 @@ _STATE_CLASS_LONG_TERM_STATS = frozenset(
 def _entity_lines(
     entities: list[EntitySnapshot],
     strings: dict[str, str],
+    ha_url: str = "",
 ) -> list[str]:
     state_label = strings["entity_state_label"]
     topic_label = strings["entity_topic_label"]
     disabled = strings["entity_disabled_marker"]
     stats_marker = strings["entity_stats_marker"]
     return [
-        f"- `{e.entity_id}` – {_md_escape(e.name)}"
+        f"- {_entity_id_md(e.entity_id, ha_url)} – {_md_escape(e.name)}"
         + (f" ({state_label}: `{e.state}`)" if e.state is not None else "")
         + (f" ({topic_label}: `{e.mqtt_topic}`)" if e.mqtt_topic else "")
         + (
@@ -805,11 +953,15 @@ def _entity_lines(
 def _automation_block(
     auto: AutomationSnapshot,
     strings: dict[str, str],
+    ha_url: str = "",
 ) -> list[str]:
+    name_md = _md_escape(auto.name)
+    edit_url = _ha_url_for(ha_url, "automation", auto.entity_id)
+    heading = f"### [{name_md}]({edit_url})" if edit_url else f"### {name_md}"
     block = [
-        f"### {_md_escape(auto.name)}",
+        heading,
         "",
-        f"- {strings['field_entity']}: `{auto.entity_id}`",
+        f"- {strings['field_entity']}: {_entity_id_md(auto.entity_id, ha_url)}",
     ]
     if auto.state is not None:
         block.append(f"- {strings['field_status']}: `{auto.state}`")
@@ -826,11 +978,15 @@ def _automation_block(
 def _script_block(
     script: ScriptSnapshot,
     strings: dict[str, str],
+    ha_url: str = "",
 ) -> list[str]:
+    name_md = _md_escape(script.name)
+    edit_url = _ha_url_for(ha_url, "script", script.entity_id)
+    heading = f"### [{name_md}]({edit_url})" if edit_url else f"### {name_md}"
     block = [
-        f"### {_md_escape(script.name)}",
+        heading,
         "",
-        f"- {strings['field_entity']}: `{script.entity_id}`",
+        f"- {strings['field_entity']}: {_entity_id_md(script.entity_id, ha_url)}",
     ]
     if script.state is not None:
         block.append(f"- {strings['field_status']}: `{script.state}`")
@@ -1188,9 +1344,14 @@ def render_helpers_auto_block(
     groups: list[HelperGroup],
     now: datetime,
     strings: dict[str, str],
+    ha_url: str = "",
 ) -> str:
     """Render the AUTO block of the Helpers page (#42)."""
     lines: list[str] = [_format_attribution(strings, now), ""]
+    helpers_url = _ha_url_for(ha_url, "helpers", "")
+    if helpers_url:
+        helpers_label = _md_escape(strings["link_helpers_in_ha"])
+        lines.extend([f"[{helpers_label}]({helpers_url})", ""])
     if not groups:
         lines.append(strings["empty_helpers"])
         return "\n".join(lines).rstrip() + "\n"
@@ -1208,7 +1369,9 @@ def render_helpers_auto_block(
         for entry in group.entries:
             state = entry.state if entry.state is not None else "—"
             lines.append(
-                f"| **{_md_escape(entry.name)}** | `{entry.entity_id}` | `{state}` |",
+                f"| **{_md_escape(entry.name)}** "
+                f"| {_entity_id_md(entry.entity_id, ha_url)} "
+                f"| `{state}` |",
             )
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"

--- a/custom_components/bookstack_sync/sync.py
+++ b/custom_components/bookstack_sync/sync.py
@@ -179,6 +179,7 @@ def _device_page(
     now: datetime,
     strings: dict[str, str],
     reverse_usage: dict[str, list] | None = None,
+    ha_url: str = "",
 ) -> _PlannedPage:
     return _PlannedPage(
         key=f"{PAGE_KIND_DEVICE}:{device.device_id}",
@@ -188,6 +189,7 @@ def _device_page(
             now,
             strings,
             reverse_usage=reverse_usage,
+            ha_url=ha_url,
         ),
         chapter_key=CHAPTER_KEY_DEVICES,
     )
@@ -197,6 +199,7 @@ def _plan_pages(
     snapshot: HASnapshot,
     now: datetime,
     strings: dict[str, str],
+    ha_url: str = "",
 ) -> list[_PlannedPage]:
     """Plan all pages EXCEPT the overview (rendered in a second pass)."""
     planned: list[_PlannedPage] = [
@@ -207,6 +210,7 @@ def _plan_pages(
                 snapshot.integrations,
                 now,
                 strings,
+                ha_url=ha_url,
             ),
         ),
         _PlannedPage(
@@ -216,17 +220,28 @@ def _plan_pages(
                 snapshot.automations,
                 now,
                 strings,
+                ha_url=ha_url,
             ),
         ),
         _PlannedPage(
             key=f"{PAGE_KIND_SCRIPTS}:_",
             title=strings["title_scripts"],
-            auto_body=render_scripts_auto_block(snapshot.scripts, now, strings),
+            auto_body=render_scripts_auto_block(
+                snapshot.scripts,
+                now,
+                strings,
+                ha_url=ha_url,
+            ),
         ),
         _PlannedPage(
             key=f"{PAGE_KIND_SCENES}:_",
             title=strings["title_scenes"],
-            auto_body=render_scenes_auto_block(snapshot.scenes, now, strings),
+            auto_body=render_scenes_auto_block(
+                snapshot.scenes,
+                now,
+                strings,
+                ha_url=ha_url,
+            ),
         ),
     ]
     if snapshot.addons:
@@ -324,19 +339,21 @@ def _plan_pages(
                     snapshot.helpers,
                     now,
                     strings,
+                    ha_url=ha_url,
                 ),
             ),
         )
-    # Areas are rendered in a SECOND pass so they can carry ``{{@<id>}}``
-    # cross-links to the device pages (v0.14.0). Pass 1 only contains
-    # bundle pages + every device — we collect their page IDs first,
-    # then ``_plan_area_pages`` renders each area on top of those IDs.
+    # Areas are rendered in a SECOND pass so they can carry cross-page
+    # Markdown links to the device pages (v0.14.0/v0.14.4). Pass 1 only
+    # contains bundle pages + every device — we collect their page IDs
+    # first, then ``_plan_area_pages`` renders each area on top of those.
     for area in snapshot.areas:
         planned.extend(
-            _device_page(d, now, strings, snapshot.reverse_usage) for d in area.devices
+            _device_page(d, now, strings, snapshot.reverse_usage, ha_url=ha_url)
+            for d in area.devices
         )
     planned.extend(
-        _device_page(d, now, strings, snapshot.reverse_usage)
+        _device_page(d, now, strings, snapshot.reverse_usage, ha_url=ha_url)
         for d in snapshot.unassigned_devices
     )
     return planned
@@ -363,6 +380,7 @@ def _plan_area_pages(
     now: datetime,
     strings: dict[str, str],
     page_links: dict[str, str],
+    ha_url: str = "",
 ) -> list[_PlannedPage]:
     """Render area pages with cross-page Markdown links to device pages."""
     return [
@@ -374,6 +392,7 @@ def _plan_area_pages(
                 now,
                 strings,
                 page_links=page_links,
+                ha_url=ha_url,
             ),
             chapter_key=CHAPTER_KEY_AREAS,
         )
@@ -439,7 +458,14 @@ async def run_sync(  # noqa: PLR0912, PLR0913, PLR0915 - cohesive 3-pass entry p
     # Registries are pure in-memory dict lookups and must run on the event
     # loop thread - never wrap them in async_add_executor_job.
     snapshot = extract_snapshot(hass, excluded_area_ids=excluded_area_ids)
-    planned = _plan_pages(snapshot, now, strings)
+    # v0.14.5: HA-frontend deep-links use this base. ``external_url``
+    # wins over ``internal_url`` because the same Markdown lands in
+    # exported .md files that the optional RAG add-on serves to the
+    # household — internal-only URLs would 404 from a phone browser
+    # outside the LAN. When neither is configured, renderers degrade
+    # silently to plain code-spans / bold labels — never broken hrefs.
+    ha_url = (hass.config.external_url or hass.config.internal_url or "").rstrip("/")
+    planned = _plan_pages(snapshot, now, strings, ha_url=ha_url)
 
     await store.async_load()
     chapters = (
@@ -481,7 +507,7 @@ async def run_sync(  # noqa: PLR0912, PLR0913, PLR0915 - cohesive 3-pass entry p
             if url:
                 page_links[page_key] = url
 
-    area_planned = _plan_area_pages(snapshot, now, strings, page_links)
+    area_planned = _plan_area_pages(snapshot, now, strings, page_links, ha_url=ha_url)
     total_steps = len(planned) + len(area_planned) + 1  # +1 for the overview
     step = 0
     for page in planned:
@@ -516,7 +542,7 @@ async def run_sync(  # noqa: PLR0912, PLR0913, PLR0915 - cohesive 3-pass entry p
     # Pass 2: render area pages (now that device URLs exist) and sync them.
     # Re-plan with the populated page_links so each area's auto-body
     # contains real cross-page Markdown links instead of bold-name fallbacks.
-    area_planned = _plan_area_pages(snapshot, now, strings, page_links)
+    area_planned = _plan_area_pages(snapshot, now, strings, page_links, ha_url=ha_url)
     for page in area_planned:
         step += 1
         try:

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -16,9 +16,12 @@ from custom_components.bookstack_sync.extractor import (
     AddonSnapshot,
     AreaSnapshot,
     AutomationSnapshot,
+    DeviceIntegrationRef,
     DeviceSnapshot,
     EntitySnapshot,
     HASnapshot,
+    HelperEntry,
+    HelperGroup,
     IntegrationSnapshot,
     NetworkInfo,
     SceneSnapshot,
@@ -30,6 +33,7 @@ from custom_components.bookstack_sync.renderer import (
     render_area_auto_block,
     render_automations_auto_block,
     render_device_auto_block,
+    render_helpers_auto_block,
     render_integrations_auto_block,
     render_network_auto_block,
     render_overview_auto_block,
@@ -68,7 +72,7 @@ def _device(device_id: str = "dev1", *, name: str = "Device 1") -> DeviceSnapsho
         sw_version="1.0",
         hw_version="A",
         area_id=None,
-        config_entries=("entry1",),
+        config_entries=(DeviceIntegrationRef(entry_id="entry1", domain="acme"),),
     )
 
 
@@ -1005,3 +1009,259 @@ class TestUsedBySectionViaGroup:
         # Bullet appears once — the bare line, no via-group annotation.
         assert out.count("- X") == 1
         assert "über Gruppe" not in out
+
+
+# ---------------------------------------------------------------------------
+# v0.14.5: HA-frontend deep-links
+
+
+_HA_URL = "http://homeassistant.local:8123"
+
+
+class TestHaLinksDevicePage:
+    """Device pages link out to the live HA UI when ``ha_url`` is set."""
+
+    def test_device_page_has_open_in_ha_line(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
+        out = render_device_auto_block(
+            _device("abc"),
+            fixed_now,
+            strings_de,
+            ha_url=_HA_URL,
+        )
+        assert (
+            f"[In Home Assistant öffnen]({_HA_URL}/config/devices/device/abc)"
+        ) in out
+
+    def test_integrations_cell_uses_domain_not_entry_id(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
+        device = _device()
+        out = render_device_auto_block(
+            device,
+            fixed_now,
+            strings_de,
+            ha_url=_HA_URL,
+        )
+        # Friendly domain rendered, not the ULID-style entry_id.
+        assert (f"[acme]({_HA_URL}/config/integrations/integration/acme)") in out
+        assert "entry1" not in out
+
+    def test_entity_id_becomes_dev_tools_link(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
+        device = _device()
+        device.entities.append(_entity("sensor.foo"))
+        out = render_device_auto_block(
+            device,
+            fixed_now,
+            strings_de,
+            ha_url=_HA_URL,
+        )
+        assert (
+            f"[`sensor.foo`]({_HA_URL}/developer-tools/state?entity_id=sensor.foo)"
+        ) in out
+
+    def test_no_ha_url_means_no_link_no_dangling_label(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
+        device = _device()
+        device.entities.append(_entity("sensor.foo"))
+        out = render_device_auto_block(device, fixed_now, strings_de)
+        assert "homeassistant" not in out
+        assert "In Home Assistant öffnen" not in out
+        # Plain code-span survives unchanged when no URL is configured.
+        assert "`sensor.foo`" in out
+
+    def test_integrations_cell_falls_back_to_plain_domain_without_ha_url(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
+        out = render_device_auto_block(_device(), fixed_now, strings_de)
+        # Domain is still shown (the v0.14.5 bug-fix), just not as a link.
+        assert "| acme |" in out
+        assert "entry1" not in out
+
+
+class TestHaLinksAreaPage:
+    """Area pages get an open-in-HA line; entity_ids in the area become links."""
+
+    def test_area_page_has_open_in_ha_line(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
+        out = render_area_auto_block(
+            AreaSnapshot(area_id="kitchen", name="Küche"),
+            fixed_now,
+            strings_de,
+            ha_url=_HA_URL,
+        )
+        assert (
+            f"[In Home Assistant öffnen]({_HA_URL}/config/areas/area/kitchen)"
+        ) in out
+
+    def test_area_automations_link_to_edit(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
+        area = AreaSnapshot(area_id="kitchen", name="Küche")
+        area.automations.append(
+            AutomationSnapshot(
+                entity_id="automation.morning_lights",
+                name="Morgenlicht",
+                description=None,
+                state="on",
+                mode=None,
+                last_triggered=None,
+            ),
+        )
+        out = render_area_auto_block(area, fixed_now, strings_de, ha_url=_HA_URL)
+        assert (
+            f"[Morgenlicht]({_HA_URL}/config/automation/edit/morning_lights)"
+        ) in out
+
+
+class TestHaLinksBundles:
+    """Automation / script / scene bundles get edit links per entry."""
+
+    def test_automation_heading_links_to_edit(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
+        out = render_automations_auto_block(
+            [
+                AutomationSnapshot(
+                    entity_id="automation.foo_bar",
+                    name="Foo Bar",
+                    description=None,
+                    state="on",
+                    mode="single",
+                    last_triggered=None,
+                ),
+            ],
+            fixed_now,
+            strings_de,
+            ha_url=_HA_URL,
+        )
+        assert (f"### [Foo Bar]({_HA_URL}/config/automation/edit/foo_bar)") in out
+
+    def test_script_heading_links_to_edit(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
+        out = render_scripts_auto_block(
+            [
+                ScriptSnapshot(
+                    entity_id="script.party_mode",
+                    name="Partymodus",
+                    description=None,
+                    state="off",
+                    last_triggered=None,
+                ),
+            ],
+            fixed_now,
+            strings_de,
+            ha_url=_HA_URL,
+        )
+        assert (f"### [Partymodus]({_HA_URL}/config/script/edit/party_mode)") in out
+
+    def test_scene_line_links_to_edit(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
+        out = render_scenes_auto_block(
+            [SceneSnapshot(entity_id="scene.movie_night", name="Filmabend")],
+            fixed_now,
+            strings_de,
+            ha_url=_HA_URL,
+        )
+        assert (f"[**Filmabend**]({_HA_URL}/config/scene/edit/movie_night)") in out
+
+
+class TestHaLinksIntegrations:
+    """Domain cell in integrations table links to the HA frontend."""
+
+    def test_domain_cell_is_clickable(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
+        out = render_integrations_auto_block(
+            [
+                IntegrationSnapshot(
+                    entry_id="abc",
+                    domain="mqtt",
+                    title="MQTT Broker",
+                    state="loaded",
+                    source="user",
+                    device_count=3,
+                    entity_count=12,
+                ),
+            ],
+            fixed_now,
+            strings_de,
+            ha_url=_HA_URL,
+        )
+        assert (f"[`mqtt`]({_HA_URL}/config/integrations/integration/mqtt)") in out
+
+
+class TestHaLinksHelpers:
+    """Helpers page gets a single sammel-link to /config/helpers."""
+
+    def test_helpers_page_links_to_helpers_section(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
+        groups = [
+            HelperGroup(
+                domain="input_boolean",
+                entries=[
+                    HelperEntry(
+                        entity_id="input_boolean.guest_mode",
+                        name="Gastmodus",
+                        domain="input_boolean",
+                        state="off",
+                        attributes={},
+                    ),
+                ],
+            ),
+        ]
+        out = render_helpers_auto_block(
+            groups,
+            fixed_now,
+            strings_de,
+            ha_url=_HA_URL,
+        )
+        assert (
+            f"[Helper-Konfiguration in Home Assistant öffnen]({_HA_URL}/config/helpers)"
+        ) in out
+        # Per-entry deep-links go through the entity_id code-span.
+        assert (
+            "[`input_boolean.guest_mode`]"
+            f"({_HA_URL}/developer-tools/state?entity_id=input_boolean.guest_mode)"
+        ) in out
+
+    def test_helpers_page_no_link_without_ha_url(
+        self,
+        fixed_now: datetime,
+        strings_de: dict[str, str],
+    ) -> None:
+        out = render_helpers_auto_block([], fixed_now, strings_de)
+        assert "Helper-Konfiguration" not in out
+        assert "/config/helpers" not in out


### PR DESCRIPTION
## Summary

- Every rendered page now links to the live Home Assistant UI when ``external_url`` / ``internal_url`` is set. Same Markdown lands in BookStack and in the exported ``.md`` files, so the planned RAG add-on can cite the URLs directly.
- Fixes the device Stammdaten table — the Integrationen cell used to display ULID-style entry_ids (``01JK17JC46PYGDD6AABQTMKGKX``); v0.14.5 shows the friendly domain (``mqtt``, ``hassio``, …) and links each one to ``/config/integrations/integration/<domain>``.
- New ``DeviceIntegrationRef`` carries both fields on ``DeviceSnapshot.config_entries``.

## What's linked

| Object | Path |
|---|---|
| Area page (top) | ``/config/areas/area/<id>`` |
| Device page (top) | ``/config/devices/device/<id>`` |
| Integrations table — domain cell | ``/config/integrations/integration/<domain>`` |
| Automation / Script heading | ``/config/<kind>/edit/<id>`` |
| Scene line | ``/config/scene/edit/<id>`` |
| Entity-IDs (everywhere) | ``/developer-tools/state?entity_id=…`` |
| Helpers page (top) | ``/config/helpers`` |

When ``external_url`` is unset everything degrades to plain code-spans / bold labels; no broken hrefs ever ship.

## Test plan

- [x] 191 unit tests pass on Python 3.14 (Ruff + Hassfest + HACS clean expected).
- [x] 13 new tests covering positive paths + ``ha_url=\"\"`` fallback + the integrations-cell regression.
- [ ] After merge: smoke-test on the Pi instance with ``force: true`` (the AUTO blocks change again, so existing pages need one forced sync to settle).

## Upgrade note

Set ``external_url`` (Settings → System → Network → URL) before the first sync. ``internal_url`` is used as fallback. With neither set, you get the v0.14.5 layout (friendly domain names!) but no clickable HA-frontend links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)