### PR TITLE
V0.14.6: live progress (Sync läuft 12/345) on the diagnostic status sensor

### DIFF
--- a/custom_components/bookstack_sync/_strings.py
+++ b/custom_components/bookstack_sync/_strings.py
@@ -198,6 +198,8 @@ _STRINGS: dict[str, dict[str, str]] = {
         # HA-Frontend deep-links (v0.14.5+)
         "link_open_in_ha": "In Home Assistant öffnen",
         "link_helpers_in_ha": "Helper-Konfiguration in Home Assistant öffnen",
+        # Diagnostic sensor live-progress (v0.14.6)
+        "sensor_state_syncing_progress_template": "Sync läuft {step}/{total}",
         # Entity-line bits
         "entity_state_label": "State",
         "entity_topic_label": "Topic",
@@ -385,6 +387,7 @@ _STRINGS: dict[str, dict[str, str]] = {
         "integration_docs_link_label": "Docs",
         "link_open_in_ha": "Open in Home Assistant",
         "link_helpers_in_ha": "Open helper configuration in Home Assistant",
+        "sensor_state_syncing_progress_template": "Syncing {step}/{total}",
         "entity_state_label": "State",
         "entity_topic_label": "Topic",
         "entity_disabled_marker": "_[disabled]_",

--- a/custom_components/bookstack_sync/coordinator.py
+++ b/custom_components/bookstack_sync/coordinator.py
@@ -78,6 +78,12 @@ class BookStackSyncCoordinator(DataUpdateCoordinator[SyncReport]):
         # "syncing" while a run is in progress. Toggled in
         # ``async_run_sync`` (try/finally so failed runs also clear it).
         self.is_syncing: bool = False
+        # Per-page progress (v0.14.6): sync.py calls ``_on_sync_progress``
+        # after each managed page so the diagnostic status sensor can
+        # show ``Sync läuft 12/345`` instead of bare ``Sync läuft``.
+        # Reset to (0, 0) at the start of every run.
+        self.current_step: int = 0
+        self.current_total: int = 0
         # Consecutive-failure counter for the "BookStack unreachable"
         # repair issue. Resets to 0 on the first successful sync.
         self._failure_streak: int = 0
@@ -178,6 +184,37 @@ class BookStackSyncCoordinator(DataUpdateCoordinator[SyncReport]):
             f"{REPAIR_ISSUE_UNREACHABLE}_{self.config_entry.entry_id}",
         )
 
+    def _on_sync_progress(self, step: int, total: int) -> None:
+        """
+        Receive a progress tick from ``run_sync`` and refresh listeners.
+
+        Called once per managed page; we just store the counts and call
+        ``async_update_listeners()`` so the diagnostic status sensor
+        re-renders. ~5 ticks/sec on a typical sync (rate-limited by
+        ``WRITE_PAUSE_SECONDS = 0.2``); fine for a diagnostic-category
+        sensor whose recorder traffic is acceptable.
+        """
+        self.current_step = step
+        self.current_total = total
+        self.async_update_listeners()
+
+    @property
+    def sync_progress_text(self) -> str | None:
+        """
+        Localised ``Sync läuft 12/345`` line for the diagnostic sensor.
+
+        Returns ``None`` when the sync hasn't reported any progress yet
+        (very brief window at the start of a run); the sensor falls back
+        to the bare ``syncing`` enum so HA's translation kicks in.
+        """
+        if self.current_total <= 0:
+            return None
+        strings = get_strings(self._resolve_output_language())
+        return strings["sensor_state_syncing_progress_template"].format(
+            step=self.current_step,
+            total=self.current_total,
+        )
+
     async def async_run_sync(
         self,
         *,
@@ -196,6 +233,8 @@ class BookStackSyncCoordinator(DataUpdateCoordinator[SyncReport]):
         """
         async with self._sync_lock:
             self.is_syncing = True
+            self.current_step = 0
+            self.current_total = 0
             self.async_update_listeners()
             try:
                 runtime = self.config_entry.runtime_data
@@ -216,6 +255,7 @@ class BookStackSyncCoordinator(DataUpdateCoordinator[SyncReport]):
                     dry_run=dry_run,
                     excluded_area_ids=excluded_areas,
                     force=force,
+                    progress_callback=self._on_sync_progress,
                 )
                 if not dry_run:
                     self.last_run = datetime.now(tz=UTC)
@@ -229,6 +269,8 @@ class BookStackSyncCoordinator(DataUpdateCoordinator[SyncReport]):
                     self._reconcile_tamper_issues(report)
             finally:
                 self.is_syncing = False
+                self.current_step = 0
+                self.current_total = 0
                 self.async_update_listeners()
         # Lock is released. Opt-in markdown back-export runs here so it
         # cannot deadlock against itself if it ever calls back into a

--- a/custom_components/bookstack_sync/manifest.json
+++ b/custom_components/bookstack_sync/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dibi73/ha-bookstack-sync/issues",
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.14.5"
+  "version": "0.14.6"
 }

--- a/custom_components/bookstack_sync/sensor.py
+++ b/custom_components/bookstack_sync/sensor.py
@@ -62,9 +62,18 @@ class BookStackSyncStatusSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def native_value(self) -> str:
-        """Top-level status: ``syncing``, ``ok``, ``error`` or ``never_run``."""
+        """
+        Top-level status: ``syncing``, ``ok``, ``error`` or ``never_run``.
+
+        v0.14.6: while syncing we replace the bare ``syncing`` enum with
+        a localised ``Sync läuft 12/345`` string when progress data is
+        available, so the diagnostic card shows live progress instead
+        of just a spinner-without-numbers. Falls back to the enum value
+        before the first progress tick so HA's state translations still
+        apply during that brief window.
+        """
         if self.coordinator.is_syncing:
-            return "syncing"
+            return self.coordinator.sync_progress_text or "syncing"
         report = self.coordinator.last_report
         if report is None:
             return "never_run"

--- a/custom_components/bookstack_sync/sync.py
+++ b/custom_components/bookstack_sync/sync.py
@@ -111,7 +111,7 @@ def _hash_from_response(
 
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
 
     from homeassistant.core import HomeAssistant
 
@@ -440,7 +440,7 @@ async def _ensure_chapters(
     return chapters
 
 
-async def run_sync(  # noqa: PLR0912, PLR0913, PLR0915 - cohesive 3-pass entry point
+async def run_sync(  # noqa: C901, PLR0912, PLR0913, PLR0915 - cohesive 3-pass entry point
     hass: HomeAssistant,
     client: BookStackApiClient,
     store: BookStackSyncStore,
@@ -450,6 +450,7 @@ async def run_sync(  # noqa: PLR0912, PLR0913, PLR0915 - cohesive 3-pass entry p
     dry_run: bool = False,
     force: bool = False,
     excluded_area_ids: Iterable[str] = (),
+    progress_callback: Callable[[int, int], None] | None = None,
 ) -> SyncReport:
     """Execute one full sync cycle and return a report."""
     report = SyncReport(dry_run=dry_run)
@@ -510,6 +511,13 @@ async def run_sync(  # noqa: PLR0912, PLR0913, PLR0915 - cohesive 3-pass entry p
     area_planned = _plan_area_pages(snapshot, now, strings, page_links, ha_url=ha_url)
     total_steps = len(planned) + len(area_planned) + 1  # +1 for the overview
     step = 0
+
+    def _emit_progress() -> None:
+        """Tell the coordinator (and via it, the status sensor) where we are."""
+        if progress_callback is not None:
+            progress_callback(step, total_steps)
+
+    _emit_progress()
     for page in planned:
         step += 1
         try:
@@ -536,6 +544,7 @@ async def run_sync(  # noqa: PLR0912, PLR0913, PLR0915 - cohesive 3-pass entry p
         except Exception as err:  # noqa: BLE001 - report and continue
             LOGGER.exception("Unexpected error syncing %s", page.key)
             report.errors.append(f"{page.key}: {err}")
+        _emit_progress()
         if not dry_run:
             await asyncio.sleep(WRITE_PAUSE_SECONDS)
 
@@ -569,6 +578,7 @@ async def run_sync(  # noqa: PLR0912, PLR0913, PLR0915 - cohesive 3-pass entry p
         except Exception as err:  # noqa: BLE001 - report and continue
             LOGGER.exception("Unexpected error syncing %s", page.key)
             report.errors.append(f"{page.key}: {err}")
+        _emit_progress()
         if not dry_run:
             await asyncio.sleep(WRITE_PAUSE_SECONDS)
 
@@ -583,6 +593,7 @@ async def run_sync(  # noqa: PLR0912, PLR0913, PLR0915 - cohesive 3-pass entry p
             page_links=page_links,
         ),
     )
+    step += 1
     try:
         await _sync_one(
             client,
@@ -602,6 +613,7 @@ async def run_sync(  # noqa: PLR0912, PLR0913, PLR0915 - cohesive 3-pass entry p
     except BookStackApiError as err:
         LOGGER.exception("BookStack sync failed for overview")
         report.errors.append(f"{overview.key}: {err}")
+    _emit_progress()
 
     all_planned = [overview, *area_planned, *planned]
     await _tombstone_orphans(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -306,3 +306,104 @@ async def test_stale_tamper_issues_resolved_after_restart(
         and issue_id.startswith(f"{REPAIR_ISSUE_TAMPERED}_{entry_id}_")
     ]
     assert remaining == [], f"stale tamper issues survived: {remaining}"
+
+
+async def test_progress_callback_updates_sensor_progress_state(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """v0.14.6: progress callback feeds the diagnostic sensor mid-sync."""
+    config_entry.add_to_hass(hass)
+    coord = _make_coordinator(hass, config_entry)
+    config_entry.runtime_data = type(
+        "RD",
+        (),
+        {"client": object(), "store": object()},
+    )()
+
+    progress_seen: list[tuple[int, int, str | None]] = []
+
+    async def fake_run_sync(*args: object, **kwargs: object) -> SyncReport:
+        progress_callback = kwargs.get("progress_callback")
+        assert progress_callback is not None, "coordinator must wire a callback"
+        progress_callback(0, 5)
+        progress_seen.append(
+            (coord.current_step, coord.current_total, coord.sync_progress_text),
+        )
+        progress_callback(2, 5)
+        progress_seen.append(
+            (coord.current_step, coord.current_total, coord.sync_progress_text),
+        )
+        progress_callback(5, 5)
+        progress_seen.append(
+            (coord.current_step, coord.current_total, coord.sync_progress_text),
+        )
+        return SyncReport(dry_run=bool(kwargs.get("dry_run")))
+
+    with patch(
+        "custom_components.bookstack_sync.coordinator.run_sync",
+        new=fake_run_sync,
+    ):
+        await coord.async_run_sync()
+
+    # First tick: total=5, step=0 — text is "X 0/5".
+    assert progress_seen[0][:2] == (0, 5)
+    assert progress_seen[0][2] is not None
+    assert "0/5" in progress_seen[0][2]
+    assert progress_seen[1][:2] == (2, 5)
+    assert "2/5" in progress_seen[1][2]
+    assert progress_seen[2][:2] == (5, 5)
+    assert "5/5" in progress_seen[2][2]
+
+    # After the run: counters reset, no progress text.
+    assert coord.current_step == 0
+    assert coord.current_total == 0
+    assert coord.sync_progress_text is None
+
+
+async def test_sync_progress_text_is_none_before_first_tick(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """No progress data yet -> property returns None so sensor falls back."""
+    config_entry.add_to_hass(hass)
+    coord = _make_coordinator(hass, config_entry)
+    assert coord.sync_progress_text is None
+
+
+async def test_sensor_state_shows_progress_string_while_syncing(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """v0.14.6: status sensor surfaces ``Sync läuft 12/345`` mid-run."""
+    from custom_components.bookstack_sync.sensor import (  # noqa: PLC0415
+        BookStackSyncStatusSensor,
+    )
+
+    config_entry.add_to_hass(hass)
+    coord = _make_coordinator(hass, config_entry)
+    sensor = BookStackSyncStatusSensor(coord)
+
+    # Before any sync: never_run.
+    assert sensor.native_value == "never_run"
+
+    # Mid-sync, no progress yet: enum-fallback so HA's state translation
+    # still kicks in for the brief pre-first-tick window.
+    coord.is_syncing = True
+    assert sensor.native_value == "syncing"
+
+    # Progress arrives — sensor now shows the formatted string.
+    coord.current_step = 12
+    coord.current_total = 345
+    state = sensor.native_value
+    assert "12/345" in state
+    # Localised — German default.
+    assert state.startswith(("Sync läuft", "Syncing"))
+
+    # Sync done: counters reset, sensor falls back to ok.
+    coord.is_syncing = False
+    coord.current_step = 0
+    coord.current_total = 0
+    coord.last_report = SyncReport()
+    coord.last_run = None  # last_run gets stamped only after successful sync
+    assert sensor.native_value == "ok"

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -478,3 +478,44 @@ async def test_force_default_false_preserves_safety(
     assert report.skipped_conflict, (
         "default run_sync (no force) must keep the tamper-skip protection"
     )
+
+
+async def test_progress_callback_is_called_with_step_and_total(
+    hass: HomeAssistant,
+    store: BookStackSyncStore,
+    strings: dict[str, str],
+) -> None:
+    """v0.14.6: each managed page emits a (step, total) progress tick."""
+    state: dict[str, Any] = {}
+    client = _fake_client_with_state(state)
+    area_reg = ar.async_get(hass)
+    area_reg.async_create("Living Room")
+
+    progress: list[tuple[int, int]] = []
+
+    def record(step: int, total: int) -> None:
+        progress.append((step, total))
+
+    await run_sync(
+        hass,
+        client,
+        store,
+        1,
+        strings,
+        progress_callback=record,
+    )
+
+    assert progress, "progress_callback was never invoked"
+    # Total stays constant for every tick within a run.
+    totals = {total for _, total in progress}
+    assert len(totals) == 1, f"total should be stable, got {totals!r}"
+    total = next(iter(totals))
+    assert total >= 6, f"expected at least 6 pages, got {total}"
+    # First emitted tick is the (0, total) seed before any page is written.
+    assert progress[0] == (0, total)
+    # Steps are monotonically non-decreasing and the final tick reaches total.
+    steps = [step for step, _ in progress]
+    assert steps == sorted(steps), f"step counter regressed: {steps!r}"
+    assert steps[-1] == total, (
+        f"final tick must show step==total, got {steps[-1]}/{total}"
+    )


### PR DESCRIPTION
## Summary

- The status sensor (entity-category ``diagnostic``) used to show only ``Sync läuft`` for the entire ~80 s run of a 400-page sync. v0.14.6 surfaces live progress: ``Sync läuft 12/345`` updates per page, fully localised (DE/EN).
- Plumbing: ``run_sync(..., progress_callback=…)`` ticks after every managed page; coordinator stores ``current_step`` / ``current_total`` and emits ``async_update_listeners()``; sensor re-renders via the existing CoordinatorEntity dataflow.
- Recorder noise: ~5 events/sec while syncing (capped by ``WRITE_PAUSE_SECONDS = 0.2``). Acceptable on a diagnostic-category sensor.

## Test plan

- [x] 195 unit tests pass on Python 3.14 (Ruff + Hassfest + HACS clean expected).
- [x] 4 new tests covering callback monotonicity, coordinator state, localised text, and the sensor's mid-sync display.

## Upgrade note

Pure addition. No ``force: true`` required — page content is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)