### PR TITLE
V0.14.9: protect pages from WYSIWYG-editor toggle damage

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -95,6 +95,20 @@ Solange du nur **innerhalb** des MANUAL-Blocks editierst, bleibt alles erhalten.
 Editierst du im AUTO-Block, erkennt der Sync das beim nächsten Lauf am Hash
 und überspringt die Page mit einer Warnung im HA-Log.
 
+> **⚠ Pages NUR im Markdown-Editor bearbeiten — nicht im WYSIWYG-Editor.**
+> BookStacks WYSIWYG-Editor (TinyMCE) konvertiert Markdown → HTML →
+> Markdown beim Wechseln und verwirft dabei stillschweigend
+> HTML-Kommentare wie `<!-- BEGIN AUTO-GENERATED -->`. Sobald die
+> Marker weg sind, kann der Sync nicht mehr unterscheiden was AUTO und
+> was MANUAL ist. Seit v0.14.9 erkennt die Integration das und
+> überspringt betroffene Pages — du siehst dann ein Repair-Issue
+> *„Marker-Kommentare einer Page fehlen"*. Recovery: Page im
+> Markdown-Editor öffnen, MANUAL-Block-Notizen woanders sichern, dann
+> *Sofort synchronisieren* mit aktiviertem *Geänderte Seiten erzwungen
+> überschreiben* aufrufen. Die Integration setzt zusätzlich bei jedem
+> Write `editor: "markdown"`, um den WYSIWYG-Toggle zu deaktivieren —
+> ältere BookStack-Versionen ignorieren das Feld aber.
+
 ## Entwicklung
 
 Repo ist auf das ludeeus-Devcontainer-Layout aufgesetzt:

--- a/README.md
+++ b/README.md
@@ -312,6 +312,19 @@ moves them to the right chapter automatically.
 
 ## Known limitations
 
+- **⚠ Edit pages in the markdown editor only — never WYSIWYG.**
+  BookStack's TinyMCE-based WYSIWYG editor round-trips Markdown
+  through HTML and silently drops HTML-comment markers
+  (`<!-- BEGIN AUTO-GENERATED -->` etc.). Once that happens, the
+  integration can no longer tell which part of the page is yours and
+  which is auto-generated. Since v0.14.9 the integration detects this
+  and refuses to overwrite affected pages — you'll see a *Marker-Kommentare
+  einer Page fehlen* repair issue in HA. Recovery: open the page in
+  the markdown editor, save your manual notes elsewhere, and re-run
+  *Sync now* with *Force overwrite tampered pages* enabled to recreate
+  the page with fresh markers. The integration also pins
+  `editor: "markdown"` on every write to deter the WYSIWYG toggle, but
+  BookStack treats that field as advisory in older versions.
 - **No bidirectional sync.** Edits in BookStack outside the manual
   block are detected, logged, and the page is skipped — not merged
   back into HA.

--- a/custom_components/bookstack_sync/_strings.py
+++ b/custom_components/bookstack_sync/_strings.py
@@ -40,7 +40,10 @@ _STRINGS: dict[str, dict[str, str]] = {
         # Default manual-block placeholder
         "default_manual_body": (
             "_Notizen, die du hier zwischen den Markern einträgst, "
-            "bleiben beim Sync erhalten._"
+            "bleiben beim Sync erhalten._\n\n"
+            "_⚠ Diese Seite NUR im Markdown-Editor bearbeiten — "
+            "der WYSIWYG-Editor zerstört die Sync-Marker und macht "
+            "die Seite für die Integration unbrauchbar._"
         ),
         # Page titles
         "title_overview": "Übersicht",
@@ -240,7 +243,10 @@ _STRINGS: dict[str, dict[str, str]] = {
             "manually."
         ),
         "default_manual_body": (
-            "_Notes you put between the markers here are preserved across syncs._"
+            "_Notes you put between the markers here are preserved across syncs._\n\n"
+            "_⚠ Edit this page ONLY in the markdown editor — the WYSIWYG "
+            "editor destroys the sync markers and breaks the page for the "
+            "integration._"
         ),
         "title_overview": "Overview",
         "title_integrations": "Integrations",

--- a/custom_components/bookstack_sync/api.py
+++ b/custom_components/bookstack_sync/api.py
@@ -145,7 +145,21 @@ class BookStackApiClient:
         if (book_id is None) == (chapter_id is None):
             msg = "create_page needs exactly one of book_id or chapter_id"
             raise BookStackApiError(msg)
-        body: dict[str, Any] = {"name": name, "markdown": markdown}
+        # ``editor: "markdown"`` is sent defensively (v0.14.9): newer
+        # BookStack versions honour it as a per-page editor pin so the
+        # WYSIWYG toggle in the UI either disappears or warns the user;
+        # older versions silently ignore unknown fields, so this never
+        # breaks. The TinyMCE HTML round-trip drops our ``<!-- BEGIN -->``
+        # marker comments; pinning the editor is the cleanest way to
+        # prevent the corruption upfront. The ``markers_missing`` repair
+        # issue and the manual-block placeholder both still warn the
+        # user explicitly because BookStack's per-page editor pin is
+        # advisory, not enforced.
+        body: dict[str, Any] = {
+            "name": name,
+            "markdown": markdown,
+            "editor": "markdown",
+        }
         if chapter_id is not None:
             body["chapter_id"] = chapter_id
         else:
@@ -170,8 +184,17 @@ class BookStackApiClient:
         (``[{"name": "...", "value": "..."}]``); BookStack overwrites the
         full tag set on update, so passing the full intended list each
         write keeps things idempotent.
+
+        ``editor: "markdown"`` is repeated on every update so a page
+        that was switched to WYSIWYG between syncs gets pulled back to
+        the markdown editor on the next write — see ``create_page`` for
+        the rationale.
         """
-        body: dict[str, Any] = {"name": name, "markdown": markdown}
+        body: dict[str, Any] = {
+            "name": name,
+            "markdown": markdown,
+            "editor": "markdown",
+        }
         if chapter_id is not None:
             body["chapter_id"] = chapter_id
         if tags is not None:

--- a/custom_components/bookstack_sync/const.py
+++ b/custom_components/bookstack_sync/const.py
@@ -90,6 +90,14 @@ EXPORT_FORMAT_VERSION = "1"
 # on Settings → System → Repairs when the integration's invariants break.
 REPAIR_ISSUE_UNREACHABLE = "bookstack_unreachable"
 REPAIR_ISSUE_TAMPERED = "page_tampered"
+# Page was previously written with both marker blocks, but on the next
+# sync at least one of them is gone. The most common cause is the user
+# toggling BookStack's WYSIWYG editor — TinyMCE's HTML round-trip drops
+# the marker comments. We refuse to overwrite the page in that state
+# (would clobber whatever's left of the user's content) and post this
+# repair issue with instructions to reset the page in the markdown
+# editor.
+REPAIR_ISSUE_MARKERS_MISSING = "page_markers_missing"
 # After how many consecutive failed sync runs we surface an "unreachable"
 # repair issue. 3 = three runs in a row before the user gets a
 # notification, so a single transient outage doesn't spam Repairs.

--- a/custom_components/bookstack_sync/coordinator.py
+++ b/custom_components/bookstack_sync/coordinator.py
@@ -25,6 +25,7 @@ from .const import (
     INTERVAL_MANUAL,
     LOGGER,
     OUTPUT_LANGUAGE_AUTO,
+    REPAIR_ISSUE_MARKERS_MISSING,
     REPAIR_ISSUE_TAMPERED,
     REPAIR_ISSUE_UNREACHABLE,
     REPAIR_ISSUE_UNREACHABLE_THRESHOLD,
@@ -93,6 +94,9 @@ class BookStackSyncCoordinator(DataUpdateCoordinator[SyncReport]):
         # repair issue is currently raised. Used to diff against the
         # latest sync report and auto-resolve issues on subsequent runs.
         self._active_tamper_keys: set[str] = set()
+        # Same shape for the v0.14.9 ``page_markers_missing`` repair
+        # issue (WYSIWYG editor toggled, marker comments dropped).
+        self._active_markers_missing_keys: set[str] = set()
         # Serialises every sync path - schedule, run_now service, preview -
         # so they cannot interleave and create duplicate pages on first run.
         self._sync_lock = asyncio.Lock()
@@ -158,6 +162,49 @@ class BookStackSyncCoordinator(DataUpdateCoordinator[SyncReport]):
         # In-memory cache kept for tests + diagnostics; no longer the
         # authoritative source.
         self._active_tamper_keys = set(current.keys())
+
+    def _reconcile_markers_missing_issues(self, report: SyncReport) -> None:
+        """
+        Create / auto-resolve ``page_markers_missing`` repair issues.
+
+        Same shape as ``_reconcile_tamper_issues`` (issue-registry is the
+        source of truth, in-memory cache only for tests/diagnostics).
+        """
+        current = dict(
+            zip(
+                report.markers_missing_page_keys,
+                report.markers_missing_page_titles,
+                strict=True,
+            ),
+        )
+        entry_id = self.config_entry.entry_id
+        prefix = f"{REPAIR_ISSUE_MARKERS_MISSING}_{entry_id}_"
+        existing = {
+            issue_id.removeprefix(prefix)
+            for (issue_domain, issue_id) in ir.async_get(self.hass).issues
+            if issue_domain == DOMAIN and issue_id.startswith(prefix)
+        }
+        new_keys = set(current.keys()) - existing
+        resolved_keys = existing - set(current.keys())
+
+        for key in new_keys:
+            ir.async_create_issue(
+                self.hass,
+                DOMAIN,
+                f"{REPAIR_ISSUE_MARKERS_MISSING}_{entry_id}_{key}",
+                is_fixable=False,
+                severity=ir.IssueSeverity.WARNING,
+                translation_key=REPAIR_ISSUE_MARKERS_MISSING,
+                translation_placeholders={"page_title": current[key]},
+            )
+        for key in resolved_keys:
+            ir.async_delete_issue(
+                self.hass,
+                DOMAIN,
+                f"{REPAIR_ISSUE_MARKERS_MISSING}_{entry_id}_{key}",
+            )
+
+        self._active_markers_missing_keys = set(current.keys())
 
     def _note_failure(self) -> None:
         """Increment the failure streak; raise repair issue at threshold."""
@@ -290,6 +337,7 @@ class BookStackSyncCoordinator(DataUpdateCoordinator[SyncReport]):
                     # so users on ``manual`` interval saw their old
                     # repair-issues hang around forever (v0.14.1 fix).
                     self._reconcile_tamper_issues(report)
+                    self._reconcile_markers_missing_issues(report)
             finally:
                 # End of sync phase. ``is_syncing`` stays True if we're
                 # about to roll into the export phase below — keeps the

--- a/custom_components/bookstack_sync/manifest.json
+++ b/custom_components/bookstack_sync/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dibi73/ha-bookstack-sync/issues",
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.14.8"
+  "version": "0.14.9"
 }

--- a/custom_components/bookstack_sync/merge.py
+++ b/custom_components/bookstack_sync/merge.py
@@ -54,6 +54,15 @@ class MergeResult:
     auto_hash: str
     auto_block_changed: bool
     manual_block_tampered: bool
+    # True when the live page exists but neither marker block could be
+    # parsed out of it. Typical cause: the user toggled BookStack's
+    # WYSIWYG editor on the page, which round-trips Markdown→HTML→Markdown
+    # via Pandoc-ish conversion and drops the ``<!-- BEGIN ... -->``
+    # comments together with whitespace structure. Treated like
+    # ``manual_block_tampered`` by the sync caller (skip the page,
+    # surface a repair issue) so we don't blow away the user's edits on
+    # the next write.
+    markers_missing: bool = False
 
 
 def _normalise_for_hash(auto_body: str) -> str:
@@ -163,6 +172,20 @@ def merge_page(
     existing_auto = extract_auto_block(existing_markdown)
     existing_manual = extract_manual_block(existing_markdown)
 
+    # WYSIWYG-toggle detection: BookStack's TinyMCE editor round-trips
+    # Markdown→HTML→Markdown and drops our ``<!-- BEGIN ... -->`` comments
+    # together with the original whitespace. If the page has content but
+    # we previously wrote a known hash AND now neither marker is parseable
+    # (or only one of them survived), the page lost its block structure.
+    # Treat that like tampering: refuse to overwrite, surface a repair
+    # issue, let the user reset the page in the markdown editor.
+    has_existing_body = bool(existing_markdown and existing_markdown.strip())
+    markers_missing = (
+        has_existing_body
+        and bool(last_known_auto_hash)
+        and (existing_auto is None or existing_manual is None)
+    )
+
     placeholder = default_manual_body or _FALLBACK_MANUAL_BODY
     manual_body = existing_manual if existing_manual is not None else placeholder
 
@@ -186,4 +209,5 @@ def merge_page(
         auto_hash=new_hash,
         auto_block_changed=auto_changed,
         manual_block_tampered=tampered,
+        markers_missing=markers_missing,
     )

--- a/custom_components/bookstack_sync/strings.json
+++ b/custom_components/bookstack_sync/strings.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "AUTO-Block einer Page wurde manuell editiert",
       "description": "Die Page „{page_title}\" in BookStack hat einen AUTO-Block der außerhalb von Home Assistant verändert wurde. Die Integration hat diese Page beim Sync übersprungen, um deine Änderungen nicht zu überschreiben. Verschiebe deine Notizen in den MANUAL-Block oder verwirf die Änderung im AUTO-Block, damit der nächste Sync die Page wieder aktualisieren kann."
+    },
+    "page_markers_missing": {
+      "title": "Marker-Kommentare einer Page fehlen",
+      "description": "Die Page „{page_title}\" in BookStack hat ihre AUTO/MANUAL-Marker-Kommentare verloren. Häufigste Ursache: der WYSIWYG-Editor wurde auf der Page geöffnet — beim Hin-und-zurück-Konvertieren zu HTML verwirft BookStack die Marker-Kommentare. Die Integration hat die Page übersprungen, um deinen Inhalt nicht zu überschreiben. Lösung: die Page im Markdown-Editor (NICHT WYSIWYG) öffnen, MANUAL-Block-Inhalte sichern, dann „Sofort synchronisieren\" mit aktiviertem „Geänderte Seiten erzwungen überschreiben\" aufrufen — damit wird die Page mit frischen Markern neu angelegt, der MANUAL-Block muss anschließend wieder eingefügt werden."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/sync.py
+++ b/custom_components/bookstack_sync/sync.py
@@ -141,6 +141,11 @@ class SyncReport:
     # Human-readable titles paired with the keys above (same length,
     # same order). Lets repair-issue translations show the page name.
     tampered_page_titles: list[str] = field(default_factory=list)
+    # Page keys + titles of pages where the marker comments are gone
+    # (typical cause: WYSIWYG-editor toggle). Same shape as the tampered
+    # lists so the coordinator can reconcile a separate repair issue.
+    markers_missing_page_keys: list[str] = field(default_factory=list)
+    markers_missing_page_titles: list[str] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
     dry_run: bool = False
 
@@ -677,7 +682,7 @@ def _post_sync_notification(
     )
 
 
-async def _sync_one(  # noqa: PLR0913 - cohesive sync step, splitting hurts clarity
+async def _sync_one(  # noqa: PLR0911, PLR0912, PLR0913, PLR0915 - cohesive sync step, splitting hurts clarity
     client: BookStackApiClient,
     store: BookStackSyncStore,
     book_id: int,
@@ -751,6 +756,29 @@ async def _sync_one(  # noqa: PLR0913 - cohesive sync step, splitting hurts clar
         last_known_auto_hash=mapping.auto_block_hash or None,
         default_manual_body=strings.get("default_manual_body"),
     )
+
+    if merged.markers_missing and not force:
+        # WYSIWYG-toggle damage: page exists, has content, was previously
+        # written with both marker blocks, but at least one marker is
+        # gone. Most common cause is the user toggling BookStack's
+        # WYSIWYG editor on the page (TinyMCE round-trip drops the
+        # ``<!-- BEGIN ... -->`` comments). Refuse to overwrite — we'd
+        # otherwise blow away whatever the user typed in the WYSIWYG
+        # session — and surface a repair issue so the user can either
+        # restore the markers manually in the markdown editor or call
+        # run_now with force=true to accept a fresh AUTO+MANUAL pair.
+        LOGGER.warning(
+            "BookStack page %s (id=%s): marker comments are missing "
+            "(WYSIWYG editor toggled?) - skipping to avoid clobbering "
+            "user content. Reset the page in the markdown editor or "
+            "re-run with force=true.",
+            page.title,
+            mapping.page_id,
+        )
+        report.skipped_conflict.append(page.title)
+        report.markers_missing_page_keys.append(page.key)
+        report.markers_missing_page_titles.append(page.title)
+        return mapping.page_id
 
     if merged.manual_block_tampered:
         if not merged.auto_block_changed:

--- a/custom_components/bookstack_sync/translations/bg.json
+++ b/custom_components/bookstack_sync/translations/bg.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "AUTO блокът на страница е редактиран ръчно",
       "description": "Страницата „{page_title}\" в BookStack има AUTO блок, който е редактиран извън Home Assistant. Интеграцията пропусна тази страница, за да не презапише вашите промени. Преместете бележките си в MANUAL блока или отменете промяната в AUTO блока, за да може следващата синхронизация да актуализира страницата отново."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/cs.json
+++ b/custom_components/bookstack_sync/translations/cs.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "AUTO blok stránky byl ručně upraven",
       "description": "Stránka „{page_title}\" v BookStack má AUTO blok, který byl upraven mimo Home Assistant. Integrace tuto stránku při synchronizaci přeskočila, aby nepřepsala vaše úpravy. Přesuňte své poznámky do bloku MANUAL nebo vraťte změnu v AUTO bloku, aby další synchronizace mohla stránku znovu aktualizovat."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/da.json
+++ b/custom_components/bookstack_sync/translations/da.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "En sides AUTO-blok er blevet redigeret manuelt",
       "description": "Siden „{page_title}\" i BookStack har en AUTO-blok, der er blevet redigeret uden for Home Assistant. Integrationen sprang denne side over ved synkronisering for ikke at overskrive dine ændringer. Flyt dine noter til MANUAL-blokken, eller fortryd ændringen i AUTO-blokken, så den næste synkronisering kan opdatere siden igen."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/de.json
+++ b/custom_components/bookstack_sync/translations/de.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "AUTO-Block einer Page wurde manuell editiert",
       "description": "Die Page „{page_title}\" in BookStack hat einen AUTO-Block der außerhalb von Home Assistant verändert wurde. Die Integration hat diese Page beim Sync übersprungen, um deine Änderungen nicht zu überschreiben. Verschiebe deine Notizen in den MANUAL-Block oder verwirf die Änderung im AUTO-Block, damit der nächste Sync die Page wieder aktualisieren kann."
+    },
+    "page_markers_missing": {
+      "title": "Marker-Kommentare einer Page fehlen",
+      "description": "Die Page „{page_title}\" in BookStack hat ihre AUTO/MANUAL-Marker-Kommentare verloren. Häufigste Ursache: der WYSIWYG-Editor wurde auf der Page geöffnet — beim Hin-und-zurück-Konvertieren zu HTML verwirft BookStack die Marker-Kommentare. Die Integration hat die Page übersprungen, um deinen Inhalt nicht zu überschreiben. Lösung: die Page im Markdown-Editor (NICHT WYSIWYG) öffnen, MANUAL-Block-Inhalte sichern, dann „Sofort synchronisieren\" mit aktiviertem „Geänderte Seiten erzwungen überschreiben\" aufrufen — damit wird die Page mit frischen Markern neu angelegt, der MANUAL-Block muss anschließend wieder eingefügt werden."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/el.json
+++ b/custom_components/bookstack_sync/translations/el.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "Το AUTO block μιας σελίδας έχει επεξεργαστεί χειροκίνητα",
       "description": "Η σελίδα „{page_title}\" στο BookStack έχει AUTO block που επεξεργάστηκε εκτός Home Assistant. Η ενσωμάτωση παρέλειψε αυτή τη σελίδα κατά τον συγχρονισμό για να μην αντικαταστήσει τις αλλαγές σας. Μετακινήστε τις σημειώσεις σας στο MANUAL block ή αναιρέστε την αλλαγή στο AUTO block, ώστε ο επόμενος συγχρονισμός να ενημερώσει ξανά τη σελίδα."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/en.json
+++ b/custom_components/bookstack_sync/translations/en.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "A page's AUTO block has been edited manually",
       "description": "The page \"{page_title}\" in BookStack has an AUTO block that was edited outside Home Assistant. The integration skipped that page on sync to avoid overwriting your edits. Move your notes into the MANUAL block, or revert the AUTO-block change, so the next sync can update the page again."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/es.json
+++ b/custom_components/bookstack_sync/translations/es.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "El bloque AUTO de una página se editó manualmente",
       "description": "La página \"{page_title}\" en BookStack tiene un bloque AUTO que se editó fuera de Home Assistant. La integración omitió esa página al sincronizar para no sobrescribir tus cambios. Mueve tus notas al bloque MANUAL o revierte el cambio en el bloque AUTO para que la próxima sincronización pueda actualizar la página de nuevo."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/et.json
+++ b/custom_components/bookstack_sync/translations/et.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "Lehe AUTO-plokki muudeti käsitsi",
       "description": "Lehel „{page_title}\" BookStackis on AUTO-plokk, mida muudeti väljaspool Home Assistanti. Integratsioon jättis selle lehe sünkroonimise vahele, et mitte kirjutada sinu muudatusi üle. Liiguta oma märkmed MANUAL-plokki või tühista AUTO-ploki muudatus, et järgmine sünkroonimine saaks lehte uuesti uuendada."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/fi.json
+++ b/custom_components/bookstack_sync/translations/fi.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "Sivun AUTO-lohkoa on muokattu manuaalisesti",
       "description": "Sivulla „{page_title}\" BookStackissa on AUTO-lohko, jota muokattiin Home Assistantin ulkopuolella. Integraatio ohitti tämän sivun synkronoinnissa, jotta muutoksiasi ei korvattaisi. Siirrä muistiinpanosi MANUAL-lohkoon tai peruuta AUTO-lohkon muutos, jotta seuraava synkronointi voi päivittää sivun uudelleen."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/fr.json
+++ b/custom_components/bookstack_sync/translations/fr.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "Le bloc AUTO d'une page a été modifié manuellement",
       "description": "La page « {page_title} » dans BookStack contient un bloc AUTO modifié en dehors de Home Assistant. L'intégration a ignoré cette page lors de la synchronisation pour ne pas écraser vos modifications. Déplacez vos notes dans le bloc MANUAL ou annulez la modification du bloc AUTO afin que la prochaine synchronisation puisse à nouveau mettre à jour la page."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/ga.json
+++ b/custom_components/bookstack_sync/translations/ga.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "Cuireadh bloc AUTO de leathanach in eagar de láimh",
       "description": "Tá bloc AUTO ag an leathanach „{page_title}\" i BookStack a cuireadh in eagar lasmuigh de Home Assistant. Lig an comhtháthú thar an leathanach seo le linn sioncronaithe chun gan d'athruithe a fhorscríobh. Bog do nótaí go dtí an bloc MANUAL nó cealaigh an t-athrú sa bhloc AUTO ionas gur féidir leis an gcéad sioncronú eile an leathanach a nuashonrú arís."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/hr.json
+++ b/custom_components/bookstack_sync/translations/hr.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "AUTO blok stranice je ručno uređen",
       "description": "Stranica „{page_title}\" u BookStacku ima AUTO blok koji je uređen izvan Home Assistanta. Integracija je preskočila tu stranicu pri sinkronizaciji kako ne bi prepisala vaše izmjene. Premjestite svoje bilješke u MANUAL blok ili poništite promjenu u AUTO bloku kako bi sljedeća sinkronizacija mogla ponovno ažurirati stranicu."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/hu.json
+++ b/custom_components/bookstack_sync/translations/hu.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "Egy oldal AUTO blokkja kézzel lett szerkesztve",
       "description": "A „{page_title}\" oldal a BookStackben olyan AUTO blokkot tartalmaz, amelyet a Home Assistanton kívül szerkesztettek. Az integráció kihagyta ezt az oldalt szinkronizálás közben, hogy ne írja felül a módosításokat. Helyezze át jegyzeteit a MANUAL blokkba, vagy vonja vissza a változtatást az AUTO blokkban, hogy a következő szinkronizálás újra frissíthesse az oldalt."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/it.json
+++ b/custom_components/bookstack_sync/translations/it.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "Il blocco AUTO di una pagina è stato modificato manualmente",
       "description": "La pagina «{page_title}» in BookStack ha un blocco AUTO che è stato modificato al di fuori di Home Assistant. L'integrazione ha saltato questa pagina durante la sincronizzazione per non sovrascrivere le tue modifiche. Sposta i tuoi appunti nel blocco MANUAL o annulla la modifica nel blocco AUTO affinché la prossima sincronizzazione possa aggiornare di nuovo la pagina."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/lt.json
+++ b/custom_components/bookstack_sync/translations/lt.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "Puslapio AUTO blokas buvo redaguotas rankiniu būdu",
       "description": "Puslapis „{page_title}\" BookStack turi AUTO bloką, kuris buvo redaguotas už Home Assistant ribų. Integracija praleido šį puslapį sinchronizavimo metu, kad neperrašytų jūsų pakeitimų. Perkelkite užrašus į MANUAL bloką arba atšaukite pakeitimą AUTO bloke, kad kitas sinchronizavimas galėtų vėl atnaujinti puslapį."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/lv.json
+++ b/custom_components/bookstack_sync/translations/lv.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "Lapas AUTO bloks rediģēts manuāli",
       "description": "Lapai „{page_title}\" BookStack ir AUTO bloks, kas tika rediģēts ārpus Home Assistant. Integrācija izlaida šo lapu sinhronizācijas laikā, lai nepārrakstītu jūsu izmaiņas. Pārvietojiet piezīmes uz MANUAL bloku vai atsauciet izmaiņas AUTO blokā, lai nākamā sinhronizācija atkal varētu atjaunināt lapu."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/mt.json
+++ b/custom_components/bookstack_sync/translations/mt.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "Il-blokk AUTO ta' paġna ġie editjat manwalment",
       "description": "Il-paġna „{page_title}\" f'BookStack għandha blokk AUTO li ġie editjat barra minn Home Assistant. L-integrazzjoni qabżet din il-paġna waqt is-sinkronizzazzjoni biex ma tikteb fuq il-bidliet tiegħek. Mexxi n-noti tiegħek fil-blokk MANUAL jew rrevoka l-bidla fil-blokk AUTO biex is-sinkronizzazzjoni li jmiss tkun tista' taġġorna l-paġna mill-ġdid."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/nb.json
+++ b/custom_components/bookstack_sync/translations/nb.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "En sides AUTO-blokk er redigert manuelt",
       "description": "Siden «{page_title}» i BookStack har en AUTO-blokk som ble redigert utenfor Home Assistant. Integrasjonen hoppet over denne siden under synkronisering for ikke å overskrive endringene dine. Flytt notatene dine til MANUAL-blokken eller angre endringen i AUTO-blokken slik at neste synkronisering kan oppdatere siden igjen."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/nl.json
+++ b/custom_components/bookstack_sync/translations/nl.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "Het AUTO-blok van een pagina is handmatig bewerkt",
       "description": "De pagina „{page_title}\" in BookStack heeft een AUTO-blok dat buiten Home Assistant is bewerkt. De integratie heeft deze pagina overgeslagen tijdens de synchronisatie om je wijzigingen niet te overschrijven. Verplaats je notities naar het MANUAL-blok of maak de wijziging in het AUTO-blok ongedaan zodat de volgende synchronisatie de pagina opnieuw kan bijwerken."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/pl.json
+++ b/custom_components/bookstack_sync/translations/pl.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "Blok AUTO strony został zedytowany ręcznie",
       "description": "Strona „{page_title}\" w BookStack zawiera blok AUTO, który został zedytowany poza Home Assistantem. Integracja pominęła tę stronę podczas synchronizacji, aby nie nadpisać Twoich zmian. Przenieś notatki do bloku MANUAL lub cofnij zmianę w bloku AUTO, aby kolejna synchronizacja mogła ponownie zaktualizować stronę."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/pt.json
+++ b/custom_components/bookstack_sync/translations/pt.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "O bloco AUTO de uma página foi editado manualmente",
       "description": "A página «{page_title}» no BookStack tem um bloco AUTO que foi editado fora do Home Assistant. A integração ignorou esta página durante a sincronização para não sobrescrever as suas alterações. Mova as suas notas para o bloco MANUAL ou anule a alteração no bloco AUTO para que a próxima sincronização possa atualizar novamente a página."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/ro.json
+++ b/custom_components/bookstack_sync/translations/ro.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "Blocul AUTO al unei pagini a fost editat manual",
       "description": "Pagina „{page_title}\" din BookStack are un bloc AUTO care a fost editat în afara Home Assistant. Integrarea a omis această pagină în timpul sincronizării pentru a nu suprascrie modificările dvs. Mutați notele în blocul MANUAL sau anulați modificarea din blocul AUTO pentru ca următoarea sincronizare să poată actualiza din nou pagina."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/sk.json
+++ b/custom_components/bookstack_sync/translations/sk.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "Blok AUTO stránky bol upravený manuálne",
       "description": "Stránka „{page_title}\" v BookStacku má blok AUTO, ktorý bol upravený mimo Home Assistant. Integrácia túto stránku počas synchronizácie preskočila, aby neprepísala vaše zmeny. Presuňte poznámky do bloku MANUAL alebo zrušte zmenu v bloku AUTO, aby ďalšia synchronizácia mohla stránku znova aktualizovať."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/sl.json
+++ b/custom_components/bookstack_sync/translations/sl.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "Blok AUTO strani je bil ročno urejen",
       "description": "Stran „{page_title}\" v BookStacku ima blok AUTO, ki je bil urejen zunaj Home Assistanta. Integracija je to stran med sinhronizacijo preskočila, da ne bi prepisala vaših sprememb. Premaknite svoje opombe v blok MANUAL ali razveljavite spremembo v bloku AUTO, da bo naslednja sinhronizacija lahko stran znova posodobila."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/sv.json
+++ b/custom_components/bookstack_sync/translations/sv.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "En sidas AUTO-block har redigerats manuellt",
       "description": "Sidan ”{page_title}” i BookStack har ett AUTO-block som har redigerats utanför Home Assistant. Integrationen hoppade över denna sida vid synkronisering för att inte skriva över dina ändringar. Flytta dina anteckningar till MANUAL-blocket eller ångra ändringen i AUTO-blocket så att nästa synkronisering kan uppdatera sidan igen."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/th.json
+++ b/custom_components/bookstack_sync/translations/th.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "บล็อก AUTO ของหน้าถูกแก้ไขด้วยตนเอง",
       "description": "หน้า „{page_title}\" ใน BookStack มีบล็อก AUTO ที่ถูกแก้ไขนอก Home Assistant การผสานรวมข้ามหน้านี้ระหว่างการซิงค์เพื่อไม่ให้เขียนทับการเปลี่ยนแปลงของคุณ ย้ายบันทึกของคุณไปยังบล็อก MANUAL หรือยกเลิกการเปลี่ยนแปลงในบล็อก AUTO เพื่อให้การซิงค์ครั้งถัดไปสามารถอัปเดตหน้าได้อีกครั้ง"
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/uk.json
+++ b/custom_components/bookstack_sync/translations/uk.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "Блок AUTO сторінки відредаговано вручну",
       "description": "Сторінка „{page_title}\" у BookStack має блок AUTO, який було відредаговано поза Home Assistant. Інтеграція пропустила цю сторінку під час синхронізації, щоб не перезаписати ваші зміни. Перенесіть свої нотатки до блоку MANUAL або скасуйте зміну в блоку AUTO, щоб наступна синхронізація могла знову оновити сторінку."
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/custom_components/bookstack_sync/translations/zh-Hans.json
+++ b/custom_components/bookstack_sync/translations/zh-Hans.json
@@ -154,6 +154,10 @@
     "page_tampered": {
       "title": "页面的 AUTO 块已被手动编辑",
       "description": "BookStack 中的页面「{page_title}」具有在 Home Assistant 之外编辑过的 AUTO 块。集成在同步期间跳过了此页面，以免覆盖您的更改。请将您的笔记移至 MANUAL 块，或撤销 AUTO 块中的更改，以便下次同步可以再次更新该页面。"
+    },
+    "page_markers_missing": {
+      "title": "A page's marker comments are missing",
+      "description": "The page \"{page_title}\" in BookStack lost its AUTO/MANUAL marker comments. Most common cause: the WYSIWYG editor was opened on the page — BookStack's HTML round-trip drops the marker comments. The integration skipped the page to avoid overwriting your content. Fix: open the page in the markdown editor (NOT WYSIWYG), copy any MANUAL-block content you want to keep, then call \"Sync now\" with \"Force overwrite tampered pages\" enabled — the page will be recreated with fresh markers and you can paste the MANUAL block back in."
     }
   },
   "exceptions": {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -173,6 +173,20 @@ class TestCreatePage:
         with pytest.raises(BookStackApiError):
             await client.create_page("P", "body")
 
+    async def test_pins_markdown_editor(self, client: BookStackApiClient) -> None:
+        # v0.14.9: every create call sends `editor: "markdown"` so newer
+        # BookStack versions hide / disable the WYSIWYG toggle on the
+        # resulting page. Older versions silently ignore the field.
+        with aioresponses() as mocked:
+            mocked.post(
+                "http://bookstack.local:6875/api/pages",
+                payload={"id": 11, "name": "P"},
+            )
+            await client.create_page("P", "body", book_id=5)
+            request_kwargs = next(iter(mocked.requests.values()))[0].kwargs
+            assert request_kwargs["json"]["editor"] == "markdown"
+            assert request_kwargs["json"]["markdown"] == "body"
+
 
 class TestUpdatePage:
     """`update_page` optionally moves the page via chapter_id."""
@@ -195,6 +209,21 @@ class TestUpdatePage:
                 payload={"id": 42, "name": "P"},
             )
             await client.update_page(42, "P", "body", chapter_id=99)
+
+    async def test_pins_markdown_editor(
+        self,
+        client: BookStackApiClient,
+    ) -> None:
+        # v0.14.9: every update call sends `editor: "markdown"` so a page
+        # that was switched to WYSIWYG between syncs gets pinned back.
+        with aioresponses() as mocked:
+            mocked.put(
+                "http://bookstack.local:6875/api/pages/42",
+                payload={"id": 42, "name": "P"},
+            )
+            await client.update_page(42, "P", "body")
+            request_kwargs = next(iter(mocked.requests.values()))[0].kwargs
+            assert request_kwargs["json"]["editor"] == "markdown"
 
 
 class TestRetryOnTransientErrors:

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -179,3 +179,87 @@ class TestMergePage:
             last_known_auto_hash=None,
         )
         assert result.manual_block_tampered is False
+
+
+class TestMarkersMissing:
+    """v0.14.9: WYSIWYG-toggle round-trip drops the marker comments.
+
+    BookStack's TinyMCE editor converts Markdown to HTML when toggled on
+    and back to Markdown when toggled off; HTML comments
+    (``<!-- BEGIN AUTO-GENERATED -->`` etc) get stripped in that
+    round-trip. The next sync would otherwise overwrite the user's
+    edits with a fresh AUTO+placeholder MANUAL pair. ``markers_missing``
+    detects that and lets the caller skip + raise a repair issue.
+    """
+
+    def test_both_markers_present_means_not_missing(self) -> None:
+        existing_full = build_page_body("auto", "user notes")
+        result = merge_page(
+            new_auto_body="auto",
+            existing_markdown=existing_full,
+            last_known_auto_hash=hash_auto_block("auto"),
+        )
+        assert result.markers_missing is False
+
+    def test_no_markers_with_known_hash_flags_missing(self) -> None:
+        # Page has content but no markers anywhere — typical WYSIWYG
+        # round-trip output.
+        result = merge_page(
+            new_auto_body="auto fresh",
+            existing_markdown="Just plain text\n\nfrom WYSIWYG round-trip",
+            last_known_auto_hash="some-old-hash",
+        )
+        assert result.markers_missing is True
+
+    def test_only_auto_marker_missing_flags_missing(self) -> None:
+        # Partial damage: MANUAL block survived, AUTO didn't.
+        existing = (
+            "Just plain text from WYSIWYG\n\n"
+            f"{MANUAL_BEGIN_MARKER}\nuser notes\n{MANUAL_END_MARKER}\n"
+        )
+        result = merge_page(
+            new_auto_body="auto fresh",
+            existing_markdown=existing,
+            last_known_auto_hash="some-old-hash",
+        )
+        assert result.markers_missing is True
+
+    def test_only_manual_marker_missing_flags_missing(self) -> None:
+        # Partial damage: AUTO block survived, MANUAL didn't.
+        existing = (
+            f"{AUTO_BEGIN_MARKER}\nauto stuff\n{AUTO_END_MARKER}\n\n"
+            "Just plain text from WYSIWYG\n"
+        )
+        result = merge_page(
+            new_auto_body="auto stuff",
+            existing_markdown=existing,
+            last_known_auto_hash=hash_auto_block("auto stuff"),
+        )
+        assert result.markers_missing is True
+
+    def test_no_markers_without_known_hash_does_not_flag(self) -> None:
+        # No stored hash means this is a brand-new page (or first-ever
+        # sync against an existing BookStack page with random content).
+        # Don't false-flag those — the caller will create or merge in
+        # the regular path.
+        result = merge_page(
+            new_auto_body="auto",
+            existing_markdown="some pre-existing text",
+            last_known_auto_hash=None,
+        )
+        assert result.markers_missing is False
+
+    def test_empty_existing_markdown_does_not_flag(self) -> None:
+        # New page (no body yet) is not "markers missing" — it's "no page".
+        result = merge_page(
+            new_auto_body="auto",
+            existing_markdown="",
+            last_known_auto_hash="some-hash",
+        )
+        assert result.markers_missing is False
+        result_none = merge_page(
+            new_auto_body="auto",
+            existing_markdown=None,
+            last_known_auto_hash="some-hash",
+        )
+        assert result_none.markers_missing is False

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -446,6 +446,75 @@ async def test_force_overwrites_tampered_pages(
     assert report_force.tampered_page_keys == []
 
 
+async def test_markers_missing_skips_page_and_records_repair_keys(
+    hass: HomeAssistant,
+    store: BookStackSyncStore,
+    strings: dict[str, str],
+) -> None:
+    """
+    v0.14.9: WYSIWYG-toggle round-trip strips the ``<!-- BEGIN ... -->``
+    marker comments. Sync must refuse to overwrite the resulting page
+    (would clobber whatever the user typed) and surface a separate
+    repair issue so it doesn't get conflated with normal tampering.
+    """
+    state: dict[str, Any] = {}
+    client = _fake_client_with_state(state)
+    area_reg = ar.async_get(hass)
+    area_reg.async_create("Living Room")
+
+    # Populate state by running a clean sync first.
+    await run_sync(hass, client, store, 1, strings)
+
+    # Simulate WYSIWYG-toggle damage on one page: replace its markdown
+    # with a plausible TinyMCE round-trip (no marker comments anywhere,
+    # whitespace-flattened — same shape Pandoc-style HTML→Markdown
+    # conversion produces).
+    page_id, page = next(iter(state["pages"].items()))
+    state["pages"][page_id] = {
+        **page,
+        "markdown": ("Living Room\n\nuser typed some notes here in WYSIWYG mode\n"),
+    }
+
+    report = await run_sync(hass, client, store, 1, strings)
+
+    # The damaged page is in skipped_conflict AND in markers_missing —
+    # not in tampered (the lists are mutually exclusive by construction).
+    assert report.skipped_conflict, (
+        "expected the markers-missing page to land in skipped_conflict"
+    )
+    assert report.markers_missing_page_keys, (
+        "expected at least one markers_missing_page_keys entry"
+    )
+    assert report.tampered_page_keys == [], (
+        "markers-missing must NOT also raise tamper — it's a distinct cause"
+    )
+
+
+async def test_markers_missing_force_overwrites(
+    hass: HomeAssistant,
+    store: BookStackSyncStore,
+    strings: dict[str, str],
+) -> None:
+    """User escape hatch: ``force=True`` accepts the page recreation."""
+    state: dict[str, Any] = {}
+    client = _fake_client_with_state(state)
+    area_reg = ar.async_get(hass)
+    area_reg.async_create("Living Room")
+
+    await run_sync(hass, client, store, 1, strings)
+    page_id, page = next(iter(state["pages"].items()))
+    state["pages"][page_id] = {
+        **page,
+        "markdown": "WYSIWYG-flattened content with no markers anywhere\n",
+    }
+
+    report = await run_sync(hass, client, store, 1, strings, force=True)
+    assert report.markers_missing_page_keys == [], (
+        f"force=True must skip markers_missing detection, got "
+        f"{report.markers_missing_page_keys!r}"
+    )
+
+
 async def test_force_default_false_preserves_safety(
     hass: HomeAssistant,
     store: BookStackSyncStore,


### PR DESCRIPTION
## Summary

Three-layer defence against BookStack's WYSIWYG-editor round-trip destroying our marker comments:

- **`merge.py:MergeResult.markers_missing`**: detects pages with non-empty body + known stored hash + at least one missing marker. `sync.py` skips those pages instead of clobbering user content; new `markers_missing_page_keys/_titles` lists carry them into the sync report. `coordinator._reconcile_markers_missing_issues` reconciles a dedicated `page_markers_missing` repair issue (registry as source of truth, same shape as the tamper reconciler). `force=True` bypasses the skip — same escape hatch as for tampering.
- **`api.create_page` / `update_page`** send `editor: "markdown"` on every write. Newer BookStack versions hide / warn-against the WYSIWYG toggle on pages with this pin; older versions silently ignore unknown fields, so it's defensive.
- **Documentation in user-visible spots**: README + README.de.md get a prominent "edit only in markdown" warning. `_strings.default_manual_body` (DE+EN) now carries a ⚠ warning line inside every freshly-created MANUAL block — so the warning is ON the page itself, visible before the first WYSIWYG click.

## Test plan

- [x] `ruff check` + `ruff format --check` green
- [x] `pytest tests/` 205/205 green in WSL Ubuntu (was 195 — added 5 in `test_merge.py:TestMarkersMissing`, 2 in `test_api.py` for the editor pin, 2 in `test_sync.py` for skip + force-override)
- [x] Translation key-parity over all 28 locales for the new `page_markers_missing` issue
- [ ] CI: lint + test + validate
- [ ] Manual: install on a real HA instance, toggle a managed page to WYSIWYG and back, run `bookstack_sync.run_now`, verify the page is skipped + a `Marker-Kommentare einer Page fehlen` repair issue appears. Then re-run with `force=true` and verify the page is recreated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
