### PR TITLE
V0.14.10: 404-recovery for deleted pages + async .storage/energy read

### DIFF
--- a/custom_components/bookstack_sync/api.py
+++ b/custom_components/bookstack_sync/api.py
@@ -40,10 +40,29 @@ class BookStackApiCommunicationError(BookStackApiError):
     """Raised on network/timeout problems."""
 
 
+class BookStackApiNotFoundError(BookStackApiCommunicationError):
+    """
+    Raised on 404 from BookStack.
+
+    Subclass of ``BookStackApiCommunicationError`` so existing
+    catch-all handlers keep working, but lets the sync orchestrator
+    treat ``page deleted in BookStack`` as a recoverable-state
+    instead of a hard failure: drop the stale mapping entry, recreate
+    the page if the underlying HA object still exists.
+    """
+
+
 def _raise_for_status(response: aiohttp.ClientResponse) -> None:
     if response.status in (401, 403):
         msg = f"BookStack rejected the API token (HTTP {response.status})"
         raise BookStackApiAuthError(msg)
+    if response.status == HTTPStatus.NOT_FOUND:
+        # 404 = the resource we asked for is gone. Most common cause:
+        # the user deleted a managed page directly in BookStack. The
+        # sync layer recovers by dropping the mapping entry and
+        # recreating the page on the next pass.
+        msg = f"BookStack resource not found ({response.url.path})"
+        raise BookStackApiNotFoundError(msg)
     response.raise_for_status()
 
 

--- a/custom_components/bookstack_sync/extractor.py
+++ b/custom_components/bookstack_sync/extractor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ipaddress
+import json
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -297,6 +298,8 @@ class HASnapshot:
 
 def extract_snapshot(  # noqa: PLR0912, PLR0915 - cohesive registry walk
     hass: HomeAssistant,
+    *,
+    energy_config: EnergyConfig | None = None,
 ) -> HASnapshot:
     """
     Build a sorted snapshot of HA registries plus auxiliary data.
@@ -305,6 +308,11 @@ def extract_snapshot(  # noqa: PLR0912, PLR0915 - cohesive registry walk
     and Supervisor add-ons (best-effort). Sort order is stable so the
     renderer can produce byte-identical output when nothing actually
     changed.
+
+    ``energy_config`` is read separately by ``async_extract_energy_config``
+    (since v0.14.10) because it needs blocking file I/O — callers fetch
+    it on the executor and pass it through here. ``None`` is fine when
+    no Energy dashboard is configured.
     """
     area_reg = ar.async_get(hass)
     device_reg = dr.async_get(hass)
@@ -430,7 +438,7 @@ def extract_snapshot(  # noqa: PLR0912, PLR0915 - cohesive registry walk
     snapshot.tts_services = _extract_services(hass, "tts")
     snapshot.recorder = _extract_recorder_config(hass)
     snapshot.mqtt_tree = _build_mqtt_topic_tree(snapshot)
-    snapshot.energy = _extract_energy_config(hass)
+    snapshot.energy = energy_config
     snapshot.helpers = _extract_helpers(hass, entity_reg)
     snapshot.reverse_usage = _extract_reverse_usage(hass)
     return snapshot
@@ -1202,22 +1210,29 @@ class EnergyConfig:
     individual_devices: list[str] = field(default_factory=list)
 
 
-def _extract_energy_config(hass: HomeAssistant) -> EnergyConfig | None:
-    """Read .storage/energy directly. Returns None when no Energy dashboard."""
-    from pathlib import Path  # noqa: PLC0415 - one-shot use
+def _read_energy_storage_blocking(storage_path: Path) -> dict | None:
+    """
+    Read ``.storage/energy`` synchronously (call via executor only).
 
-    storage_path = Path(hass.config.path(".storage", "energy"))
+    Blocking I/O — ``hass.async_add_executor_job`` is the right
+    transport. HA's loop guard (since 2025) raises a warning when
+    called directly from the event loop. Returns the parsed JSON
+    payload, or ``None`` if the file is missing / unreadable.
+    """
     if not storage_path.is_file():
         return None
     try:
-        import json  # noqa: PLC0415 - one-shot use
-
         with storage_path.open(encoding="utf-8") as f:
-            payload = json.load(f)
+            return json.load(f)
     except (OSError, ValueError) as err:
         LOGGER.debug("Could not read .storage/energy: %s", err)
         return None
 
+
+def _parse_energy_payload(payload: dict | None) -> EnergyConfig | None:
+    """Parse a ``.storage/energy`` payload into ``EnergyConfig`` (pure)."""
+    if not payload:
+        return None
     data = (payload.get("data") if isinstance(payload, dict) else None) or {}
     cfg = EnergyConfig()
 
@@ -1245,6 +1260,23 @@ def _extract_energy_config(hass: HomeAssistant) -> EnergyConfig | None:
     if not cfg.sources and not cfg.individual_devices:
         return None
     return cfg
+
+
+async def async_extract_energy_config(hass: HomeAssistant) -> EnergyConfig | None:
+    """
+    Read + parse ``.storage/energy`` without blocking the event loop.
+
+    Pre-step for ``extract_snapshot``: callers fetch the energy config
+    via this async helper and pass the result through the snapshot
+    pipeline. v0.14.10 split this off ``extract_snapshot`` so HA's
+    blocking-I/O guard stops warning on every sync.
+    """
+    storage_path = Path(hass.config.path(".storage", "energy"))
+    payload = await hass.async_add_executor_job(
+        _read_energy_storage_blocking,
+        storage_path,
+    )
+    return _parse_energy_payload(payload)
 
 
 # ----- #42 Helpers ------------------------------------------------------------

--- a/custom_components/bookstack_sync/manifest.json
+++ b/custom_components/bookstack_sync/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dibi73/ha-bookstack-sync/issues",
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.14.9"
+  "version": "0.14.10"
 }

--- a/custom_components/bookstack_sync/store.py
+++ b/custom_components/bookstack_sync/store.py
@@ -112,6 +112,16 @@ class BookStackSyncStore:
         """Insert or replace a mapping in-memory (call async_save to persist)."""
         self._state.pages[key] = mapping
 
+    def discard(self, key: str) -> None:
+        """
+        Drop a mapping if present (call async_save to persist).
+
+        Used when BookStack returns 404 for a page we previously
+        managed — the page was deleted in BookStack, so the stored
+        mapping is stale and will block recreation if we keep it.
+        """
+        self._state.pages.pop(key, None)
+
     def all(self) -> dict[str, PageMapping]:
         """Return a shallow copy of all known mappings."""
         return dict(self._state.pages)

--- a/custom_components/bookstack_sync/sync.py
+++ b/custom_components/bookstack_sync/sync.py
@@ -25,7 +25,11 @@ from homeassistant.components.persistent_notification import (
     async_create as async_create_notification,
 )
 
-from .api import BookStackApiAuthError, BookStackApiError
+from .api import (
+    BookStackApiAuthError,
+    BookStackApiError,
+    BookStackApiNotFoundError,
+)
 from .const import (
     CHAPTER_KEY_AREAS,
     CHAPTER_KEY_DEVICES,
@@ -49,7 +53,7 @@ from .const import (
     TAG_VALUE_MANAGED,
     TAG_VALUE_ORPHANED,
 )
-from .extractor import extract_snapshot
+from .extractor import async_extract_energy_config, extract_snapshot
 from .merge import (
     build_page_body,
     extract_auto_block,
@@ -461,8 +465,12 @@ async def run_sync(  # noqa: C901, PLR0912, PLR0913, PLR0915 - cohesive 3-pass e
     now = datetime.now(tz=UTC)
 
     # Registries are pure in-memory dict lookups and must run on the event
-    # loop thread - never wrap them in async_add_executor_job.
-    snapshot = extract_snapshot(hass)
+    # loop thread - never wrap them in async_add_executor_job. The
+    # Energy-Dashboard config however is read from ``.storage/energy``,
+    # so we fetch it here on the executor (v0.14.10) and inject it into
+    # the otherwise-sync snapshot pipeline.
+    energy_config = await async_extract_energy_config(hass)
+    snapshot = extract_snapshot(hass, energy_config=energy_config)
     # v0.14.5: HA-frontend deep-links use this base. ``external_url``
     # wins over ``internal_url`` because the same Markdown lands in
     # exported .md files that the optional RAG add-on serves to the
@@ -682,7 +690,7 @@ def _post_sync_notification(
     )
 
 
-async def _sync_one(  # noqa: PLR0911, PLR0912, PLR0913, PLR0915 - cohesive sync step, splitting hurts clarity
+async def _sync_one(  # noqa: PLR0911, PLR0913, PLR0915 - cohesive sync step, splitting hurts clarity
     client: BookStackApiClient,
     store: BookStackSyncStore,
     book_id: int,
@@ -708,7 +716,8 @@ async def _sync_one(  # noqa: PLR0911, PLR0912, PLR0913, PLR0915 - cohesive sync
         page.title,
     )
 
-    if mapping is None:
+    async def _create_fresh() -> int | None:
+        """Create the BookStack page from scratch (no usable mapping)."""
         if dry_run:
             report.created.append(page.title)
             return None
@@ -743,7 +752,25 @@ async def _sync_one(  # noqa: PLR0911, PLR0912, PLR0913, PLR0915 - cohesive sync
         report.created.append(page.title)
         return page_id
 
-    existing = await client.get_page(mapping.page_id)
+    if mapping is None:
+        return await _create_fresh()
+
+    try:
+        existing = await client.get_page(mapping.page_id)
+    except BookStackApiNotFoundError:
+        # v0.14.10: page was deleted directly in BookStack between
+        # syncs. Pre-fix this raised BookStackApiCommunicationError
+        # which aborted the whole area's sync; now we drop the stale
+        # mapping and recreate the page so the user's HA object stays
+        # documented.
+        LOGGER.warning(
+            "BookStack page %s was tracked under id=%s but is gone "
+            "from BookStack — dropping stale mapping and recreating.",
+            page.title,
+            mapping.page_id,
+        )
+        store.discard(page.key)
+        return await _create_fresh()
     needs_move = _needs_move(existing, chapter_id, page.key)
 
     existing_markdown = existing.get("markdown") or existing.get("raw_html") or ""
@@ -983,7 +1010,20 @@ async def _tombstone_one(  # noqa: PLR0913 - cohesive sync step
 ) -> None:
     auto_body = render_tombstone_auto_block(strings, now)
 
-    existing = await client.get_page(mapping.page_id)
+    try:
+        existing = await client.get_page(mapping.page_id)
+    except BookStackApiNotFoundError:
+        # v0.14.10: page is gone from BookStack already — the user
+        # deleted it directly. Nothing left to tombstone; just clear
+        # the stale mapping entry so future runs don't re-trigger
+        # this path.
+        LOGGER.info(
+            "BookStack page id=%s (%s) already gone — clearing tombstone mapping.",
+            mapping.page_id,
+            key,
+        )
+        store.discard(key)
+        return
     existing_markdown = existing.get("markdown") or existing.get("raw_html") or ""
 
     merged = merge_page(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,6 +22,7 @@ from custom_components.bookstack_sync.api import (
     BookStackApiClient,
     BookStackApiCommunicationError,
     BookStackApiError,
+    BookStackApiNotFoundError,
 )
 
 
@@ -224,6 +225,30 @@ class TestUpdatePage:
             await client.update_page(42, "P", "body")
             request_kwargs = next(iter(mocked.requests.values()))[0].kwargs
             assert request_kwargs["json"]["editor"] == "markdown"
+
+
+class TestNotFoundError:
+    """v0.14.10: 404 must raise the dedicated NotFoundError subclass."""
+
+    async def test_get_page_404_raises_not_found(
+        self,
+        client: BookStackApiClient,
+    ) -> None:
+        with aioresponses() as mocked:
+            mocked.get(
+                "http://bookstack.local:6875/api/pages/999",
+                status=404,
+                payload={"error": {"code": 404, "message": "Page not found"}},
+            )
+            with pytest.raises(BookStackApiNotFoundError):
+                await client.get_page(999)
+
+    async def test_not_found_is_communication_error_subclass(self) -> None:
+        # Existing handlers that catch BookStackApiCommunicationError still
+        # see 404s — important for the export pipeline which already
+        # logs+skips at that level.
+        assert issubclass(BookStackApiNotFoundError, BookStackApiCommunicationError)
+        assert issubclass(BookStackApiNotFoundError, BookStackApiError)
 
 
 class TestRetryOnTransientErrors:

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -21,7 +21,11 @@ from homeassistant.helpers import (
 )
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.bookstack_sync.extractor import extract_snapshot
+from custom_components.bookstack_sync.extractor import (
+    _parse_energy_payload,
+    async_extract_energy_config,
+    extract_snapshot,
+)
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -549,3 +553,71 @@ def test_package_modules_all_parse() -> None:
     for py_file in pkg.rglob("*.py"):
         with py_file.open(encoding="utf-8") as f:
             ast.parse(f.read(), filename=str(py_file))
+
+
+async def test_async_extract_energy_config_uses_executor(
+    hass: HomeAssistant,
+    tmp_path,
+) -> None:
+    """
+    v0.14.10: Energy-Dashboard config is read via async_add_executor_job
+    so HA's blocking-I/O loop guard (since 2025) doesn't warn on every
+    sync. Reads an actual file off-thread and parses it.
+    """
+    import json  # noqa: PLC0415 - test-only
+
+    storage_dir = tmp_path / ".storage"
+    storage_dir.mkdir()
+    (storage_dir / "energy").write_text(
+        json.dumps(
+            {
+                "data": {
+                    "energy_sources": [
+                        {
+                            "type": "grid",
+                            "stat_consumption": "sensor.grid_in",
+                            "stat_energy_to": "sensor.grid_out",
+                        },
+                    ],
+                    "device_consumption": [
+                        {"stat_consumption": "sensor.fridge_kwh"},
+                    ],
+                },
+            },
+        ),
+        encoding="utf-8",
+    )
+    hass.config.config_dir = str(tmp_path)
+
+    cfg = await async_extract_energy_config(hass)
+    assert cfg is not None
+    assert any(s.type == "grid" for s in cfg.sources)
+    assert "sensor.fridge_kwh" in cfg.individual_devices
+
+
+async def test_async_extract_energy_config_returns_none_when_missing(
+    hass: HomeAssistant,
+    tmp_path,
+) -> None:
+    """No ``.storage/energy`` file = no energy dashboard configured."""
+    hass.config.config_dir = str(tmp_path)
+    cfg = await async_extract_energy_config(hass)
+    assert cfg is None
+
+
+def test_parse_energy_payload_pure() -> None:
+    """The parser is pure (no IO) so it stays unit-testable post-split."""
+    cfg = _parse_energy_payload(
+        {
+            "data": {
+                "energy_sources": [{"type": "solar", "name": "PV"}],
+                "device_consumption": [{"stat_consumption": "sensor.boiler"}],
+            },
+        },
+    )
+    assert cfg is not None
+    assert cfg.sources[0].type == "solar"
+    assert cfg.individual_devices == ["sensor.boiler"]
+
+    assert _parse_energy_payload(None) is None
+    assert _parse_energy_payload({}) is None

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -446,6 +446,106 @@ async def test_force_overwrites_tampered_pages(
     assert report_force.tampered_page_keys == []
 
 
+async def test_404_on_get_page_recreates_page_and_keeps_sync_running(
+    hass: HomeAssistant,
+    store: BookStackSyncStore,
+    strings: dict[str, str],
+) -> None:
+    """
+    v0.14.10: a managed page deleted directly in BookStack used to
+    abort the whole area's sync with a BookStackApiCommunicationError
+    (logged: ``area:foo: BookStack request failed: 404``). Now we
+    treat 404 on get_page as ``page gone`` — drop the stale mapping,
+    recreate the page from scratch, the rest of the sync runs through.
+    """
+    from custom_components.bookstack_sync.api import (  # noqa: PLC0415
+        BookStackApiNotFoundError,
+    )
+
+    state: dict[str, Any] = {}
+    client = _fake_client_with_state(state)
+    area_reg = ar.async_get(hass)
+    area_reg.async_create("Living Room")
+
+    # First sync establishes mappings.
+    await run_sync(hass, client, store, 1, strings)
+
+    # Pick one mapping, simulate the page being deleted in BookStack:
+    # next get_page for that id raises 404. Other pages still resolve
+    # via the normal stub.
+    target_key, target_mapping = next(iter(store.all().items()))
+    deleted_id = target_mapping.page_id
+    real_get_page = client.get_page.side_effect
+
+    async def get_page_404_for_target(page_id: int) -> dict[str, Any]:
+        if page_id == deleted_id:
+            msg = f"BookStack resource not found (/api/pages/{page_id})"
+            raise BookStackApiNotFoundError(msg)
+        return await real_get_page(page_id)
+
+    client.get_page = AsyncMock(side_effect=get_page_404_for_target)
+    # Also drop the page from BookStack-state so the recreated id is
+    # genuinely fresh.
+    state["pages"].pop(deleted_id, None)
+
+    report = await run_sync(hass, client, store, 1, strings)
+
+    # The full run completes without a hard error, the deleted page
+    # gets recreated.
+    assert report.errors == [], f"unexpected errors: {report.errors}"
+    new_mapping = store.get(target_key)
+    assert new_mapping is not None
+    assert new_mapping.page_id != deleted_id, "stale mapping should have been replaced"
+
+
+async def test_404_on_tombstone_clears_mapping_silently(
+    hass: HomeAssistant,
+    store: BookStackSyncStore,
+    strings: dict[str, str],
+) -> None:
+    """
+    Page is gone AND HA object is gone: tombstone path used to crash
+    on get_page 404; now it just discards the mapping.
+    """
+    from custom_components.bookstack_sync.api import (  # noqa: PLC0415
+        BookStackApiNotFoundError,
+    )
+
+    state: dict[str, Any] = {}
+    client = _fake_client_with_state(state)
+    area_reg = ar.async_get(hass)
+    living = area_reg.async_create("Living Room")
+
+    await run_sync(hass, client, store, 1, strings)
+
+    # Remove the area in HA so the next sync runs the tombstone path
+    # for it. Also delete the page from BookStack so the tombstone
+    # write would 404.
+    area_reg.async_delete(living.id)
+    area_keys = [k for k in store.all() if k.startswith("area:")]
+    assert area_keys, "test setup expected at least one area mapping"
+    target_key = area_keys[0]
+    target_mapping = store.get(target_key)
+    deleted_id = target_mapping.page_id
+    state["pages"].pop(deleted_id, None)
+    real_get_page = client.get_page.side_effect
+
+    async def get_page_404_for_target(page_id: int) -> dict[str, Any]:
+        if page_id == deleted_id:
+            msg = f"BookStack resource not found (/api/pages/{page_id})"
+            raise BookStackApiNotFoundError(msg)
+        return await real_get_page(page_id)
+
+    client.get_page = AsyncMock(side_effect=get_page_404_for_target)
+
+    report = await run_sync(hass, client, store, 1, strings)
+
+    assert report.errors == [], f"unexpected errors: {report.errors}"
+    assert store.get(target_key) is None, (
+        "tombstone path should have dropped the stale mapping"
+    )
+
+
 async def test_markers_missing_skips_page_and_records_repair_keys(
     hass: HomeAssistant,
     store: BookStackSyncStore,


### PR DESCRIPTION
## Summary

Two bugs found by inspecting the live HA log of a production install:

### (a) 404 on `get_page` aborts the area's sync

Log evidence: `area:arbeitszimmer: BookStack request failed: 404, url='<bookstack>/api/pages/7'`. Cause: a managed page was deleted directly in BookStack; the next `client.get_page(stale_id)` raised `BookStackApiCommunicationError`, which the `_sync_one` orchestrator treated as a hard failure for the entire area.

Fix:
- New `BookStackApiNotFoundError(BookStackApiCommunicationError)` raised by `_raise_for_status` for HTTP 404. Subclass means catch-all `BookStackApiCommunicationError` handlers (export pipeline) keep working.
- `_sync_one` catches it: `store.discard(page.key)`, then recreates the page via a local `_create_fresh()` helper extracted from the `mapping is None` branch (no code duplication).
- `_tombstone_one` catches it: clears the mapping silently (page gone + HA object gone = nothing to tombstone).

### (b) Blocking `open()` in event loop

Log evidence: `Detected blocking call to open with args (PosixPath('/config/.storage/energy'),) inside the event loop by custom integration 'bookstack_sync'` — count=4 per sync. HA's loop guard warns now; future HA versions will block hard.

Fix: split `_extract_energy_config` into three:
- `_read_energy_storage_blocking(path)` — sync I/O, must go through `async_add_executor_job`.
- `_parse_energy_payload(payload)` — pure, unit-testable.
- `async_extract_energy_config(hass)` — async wrapper.

`extract_snapshot` now takes `energy_config` as an injected param; `run_sync` fetches it on the executor before the otherwise-sync snapshot pipeline.

## Test plan

- [x] `ruff check` + `ruff format --check` green
- [x] `pytest tests/` 212/212 green in WSL Ubuntu (was 205, +7 new)
- [ ] CI: lint + test + validate
- [ ] Manual: install on real HA. Verify the `area:arbeitszimmer` page that was 404'ing recreates cleanly. Verify HA log no longer shows `Detected blocking call to open` for `bookstack_sync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
