### PR TITLE
v0.14.11: dependabot cluster — ruff 0.15.13, pip 26.1.1, pytest <10

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-pytest<9
+pytest<10
 pytest-asyncio<2
 pytest-cov
 aioresponses

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorlog==6.10.1
 homeassistant==2026.3.2
-pip>=26.1
-ruff==0.15.12
+pip>=26.1.1
+ruff==0.15.13


### PR DESCRIPTION
## Summary

Consolidates three open Dependabot bumps into one release per the v0.1.1 cluster pattern, avoiding three sequential rebase cascades.

- `ruff` `0.15.12` → `0.15.13` (closes #91) — patch with F811/ERA001/PYI016 false-positive fixes
- `pip` `>=26.1` → `>=26.1.1` (closes #89) — patch reverting an accidental `__pycache__` cleanup change
- `pytest` `<9` → `<10` (closes #25) — opens the constraint to the pytest 9 line, which brings the fix for CVE-2025-71176 (insecure temporary directory). `pytest-homeassistant-custom-component` already supports pytest 9.

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `ruff format --check .` — 33 files already formatted
- [x] `pytest -q` — 212/212 passing under pytest 9.0.0 in WSL Ubuntu / Python 3.14.4
- [ ] CI green on this PR
