### PR TITLE
v0.14.12: security maintenance — HA 2026.5.3 + pytest 9.0.3

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-pytest<10
+pytest>=9.0.3,<10
 pytest-asyncio<2
 pytest-cov
 aioresponses

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorlog==6.10.1
-homeassistant==2026.3.2
+homeassistant==2026.5.3
 pip>=26.1.1
 ruff==0.15.13


### PR DESCRIPTION
## Summary

Security-maintenance release prompted by the post-v0.14.11 vulnerability scan (`pip-audit` + Sonatype OSS Index). Closes a cluster of CVEs in the HA-transitive chain plus pytest itself with two pin tightenings.

### Bumps

- **`homeassistant`** `2026.3.2` → `2026.5.3` — pulls in fixed transitives:
  - `cryptography 47.0.0` — CVE-2026-39892 (CVSS **9.8** memory-buffer overflow)
  - `pyopenssl 26.1.0` — CVE-2026-27459 (CVSS **9.8** buffer overflow)
  - `aiohttp 3.13.5` — 10 CVEs incl. CVE-2026-34515 (path traversal)
  - `pillow 12.2.0` — 5 CVEs incl. CVE-2026-42311 (integer overflow)
  - `pyjwt 2.12.1` — CVE-2026-32597
  - `requests 2.33.1`, `uv 0.11.8`
- **`pytest`** `<10` → `>=9.0.3,<10` — pytest 9.0.0 still has CVE-2025-71176 (insecure temp dir); fix landed in 9.0.3. `pytest-homeassistant-custom-component 0.13.332` pins `pytest==9.0.3` exactly, so the range stays compatible.

### No code changes

Pure dependency-pin update — `extractor.py`, `sync.py`, etc untouched. Tests verify behaviour against the upgraded stack.

## Test plan

- [x] `ruff check .` — clean
- [x] `ruff format --check .` — 33 files already formatted
- [x] `pytest -q` — 212/212 passing under HA 2026.5.3 + pytest 9.0.3 (WSL Ubuntu / Python 3.14.4)
- [ ] CI green
